### PR TITLE
(WIP) feat/amenities - Suggestions for Amenities

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -17,10 +17,41 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
 
   @Override
   public void processFeature(SourceFeature sf, FeatureCollector features) {
-    if (sf.isPoint() && (sf.hasTag("amenity") ||
-      sf.hasTag("shop") ||
-      sf.hasTag("tourism") ||
-      sf.hasTag("railway", "station"))) {
+    if (sf.isPoint() && (
+        sf.hasTag("amenity") ||
+        sf.hasTag("shop") ||
+        sf.hasTag("tourism") ||
+        sf.hasTag("railway", "station")||
+        sf.hasTag("office") ||
+        sf.hasTag("historic") ||
+        sf.hasTag("leisure") ||
+        sf.hasTag("craft") ||
+        sf.hasTag("sport")
+      )) {
+
+      String kind = "node";
+      String tag = "amenity";
+      if(sf.hasTag("amenity")){
+        tag = kind = "amenity";
+      } else if(sf.hasTag("shop")){
+        tag = kind = "shop";
+      } else if(sf.hasTag("tourism")){
+        tag = kind = "tourism";
+      } else if(sf.hasTag("office")){
+        tag = kind = "office";
+      } else if(sf.hasTag("historic")){
+        tag = kind = "historic";
+      } else if(sf.hasTag("leisure")){
+        tag = kind = "leisure";
+      } else if(sf.hasTag("craft")){
+        tag = kind = "craft";
+      } else if(sf.hasTag("sport")){
+        tag = kind = "sport";
+      }
+      if(kind != "node"){
+        tag= sf.getString(kind);
+      }
+
       var feature = features.point(this.name())
         .setId(FeatureId.create(sf))
         .setAttr("amenity", sf.getString("amenity"))
@@ -29,7 +60,16 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
         .setAttr("cuisine", sf.getString("cuisine"))
         .setAttr("religion", sf.getString("religion"))
         .setAttr("tourism", sf.getString("tourism"))
-        .setZoomRange(13, 15);
+        .setAttr("tourism", sf.getString("sport"))
+
+        // Allows zoom rendering by star rating
+        .setAttr("stars", sf.getString("stars"))
+
+        // Allows dynamic icon by generic kind or specific tag
+        .setAttr("pmap:kind", kind)
+        .setAttr("pmap:tag", tag)
+
+        .setZoomRange(12, 15);
 
       OsmNames.setOsmNames(feature, sf, 0);
     }

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -17,39 +17,37 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
 
   @Override
   public void processFeature(SourceFeature sf, FeatureCollector features) {
-    if (sf.isPoint() && (
-        sf.hasTag("amenity") ||
-        sf.hasTag("shop") ||
-        sf.hasTag("tourism") ||
-        sf.hasTag("railway", "station")||
-        sf.hasTag("office") ||
-        sf.hasTag("historic") ||
-        sf.hasTag("leisure") ||
-        sf.hasTag("craft") ||
-        sf.hasTag("sport")
-      )) {
+    if (sf.isPoint() && (sf.hasTag("amenity") ||
+      sf.hasTag("shop") ||
+      sf.hasTag("tourism") ||
+      sf.hasTag("railway", "station") ||
+      sf.hasTag("office") ||
+      sf.hasTag("historic") ||
+      sf.hasTag("leisure") ||
+      sf.hasTag("craft") ||
+      sf.hasTag("sport"))) {
 
       String kind = "node";
       String tag = "amenity";
-      if(sf.hasTag("amenity")){
+      if (sf.hasTag("amenity")) {
         tag = kind = "amenity";
-      } else if(sf.hasTag("shop")){
+      } else if (sf.hasTag("shop")) {
         tag = kind = "shop";
-      } else if(sf.hasTag("tourism")){
+      } else if (sf.hasTag("tourism")) {
         tag = kind = "tourism";
-      } else if(sf.hasTag("office")){
+      } else if (sf.hasTag("office")) {
         tag = kind = "office";
-      } else if(sf.hasTag("historic")){
+      } else if (sf.hasTag("historic")) {
         tag = kind = "historic";
-      } else if(sf.hasTag("leisure")){
+      } else if (sf.hasTag("leisure")) {
         tag = kind = "leisure";
-      } else if(sf.hasTag("craft")){
+      } else if (sf.hasTag("craft")) {
         tag = kind = "craft";
-      } else if(sf.hasTag("sport")){
+      } else if (sf.hasTag("sport")) {
         tag = kind = "sport";
       }
-      if(kind != "node"){
-        tag= sf.getString(kind);
+      if (kind != "node") {
+        tag = sf.getString(kind);
       }
 
       var feature = features.point(this.name())


### PR DESCRIPTION
- include amenity, shop, tourism, office, historic, leisure, craft and sport nodes
- set `pmap:kind` with the tag name
- set `pmap:tag` with the tag value
- set `pmap:stars` with the rating value

These changes allow the map layer to render the amenities with a single icon as a whole, or icons by tag name or value, or at different map zoom levels by the star rating.