### PR TITLE
Filter old tracks

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -21,7 +21,7 @@ public class Roads implements ForwardingProfile.FeatureProcessor, ForwardingProf
   @Override
   public void processFeature(SourceFeature sourceFeature, FeatureCollector features) {
     if (sourceFeature.canBeLine() && sourceFeature.hasTag("highway") &&
-      !(sourceFeature.hasTag("highway", "proposed", "construction"))) {
+      !(sourceFeature.hasTag("highway", "proposed", "abandoned", "razed", "demolished", "removed", "construction"))) {
       String highway = sourceFeature.getString("highway");
       var feat = features.line("roads")
         .setId(FeatureId.create(sourceFeature))

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Transit.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Transit.java
@@ -22,7 +22,7 @@ public class Transit implements ForwardingProfile.FeatureProcessor, ForwardingPr
       sf.hasTag("aerialway", "cable_car") ||
       sf.hasTag("route", "ferry") ||
       sf.hasTag("aeroway", "runway", "taxiway")) &&
-      (!sf.hasTag("railway", "abandoned", "construction", "platform", "proposed"))) {
+      (!sf.hasTag("railway", "abandoned", "razed", "demolished", "removed", "construction", "platform", "proposed"))) {
 
       int minzoom = 11;
 


### PR DESCRIPTION
according to: https://wiki.openstreetmap.org/wiki/Lifecycle_prefix

This should remove some old, unused and removed railways/highways.

https://taginfo.openstreetmap.org/tags/razed%3Arailway
especially railways looked weird in my area without this filter

Todo: update docs (I didn't find them in this repo)