### PR TITLE
tileset: fix population parsing of commas.

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
@@ -1,5 +1,7 @@
 package com.protomaps.basemap.layers;
 
+import static com.onthegomap.planetiler.util.Parse.parseIntOrNull;
+
 import com.onthegomap.planetiler.FeatureCollector;
 import com.onthegomap.planetiler.ForwardingProfile;
 import com.onthegomap.planetiler.VectorTile;
@@ -78,7 +80,7 @@ public class Places implements ForwardingProfile.FeatureProcessor, ForwardingPro
     if (sf.isPoint() &&
       (sf.hasTag("place", "suburb", "town", "village", "neighbourhood", "city", "country", "state", "province"))) {
       Integer population =
-        sf.getString("population") == null ? 0 : (int) Double.parseDouble(sf.getString("population"));
+        sf.getString("population") == null ? 0 : parseIntOrNull(sf.getString("population"));
       var feat = features.point(this.name())
         .setId(FeatureId.create(sf))
         .setAttr("place", sf.getString("place"))


### PR DESCRIPTION
@nvkelso this ignores OSM population tag values that have commas in them (though we should either fix them upstream or handle those correctly)