### PR TITLE
Add layer for country boundaries solid lines

### DIFF
--- a/base/src/base_layers.ts
+++ b/base/src/base_layers.ts
@@ -798,10 +798,22 @@ export function nolabels_layers(source: string, c: Theme): any[] {
       },
     },
     {
+      id: "boundaries_country",
+      type: "line",
+      source: source,
+      "source-layer": "boundaries",
+      filter: ["<=", "pmap:min_admin_level", 2],
+      paint: {
+        "line-color": c.boundaries,
+        "line-width": 1,
+      },
+    },
+    {
       id: "boundaries",
       type: "line",
       source: source,
       "source-layer": "boundaries",
+      filter: [">", "pmap:min_admin_level", 2],
       paint: {
         "line-color": c.boundaries,
         "line-width": 0.5,


### PR DESCRIPTION
adds a `boundaries_country` layer for styling country boundaries with a solid line, as opposed to the dashed line that was used for all country/state/province boundaries