### PR TITLE
stop road links from disappearing z < 12 [#53]

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -131,7 +131,7 @@ public class Roads implements ForwardingProfile.FeatureProcessor, ForwardingProf
 
       if (sourceFeature.hasTag("highway", "motorway_link", "trunk_link", "primary_link", "secondary_link",
         "tertiary_link")) {
-        feat.setAttrWithMinzoom("pmap:link", 1, 12);
+        feat.setAttr("pmap:link", 1);
       }
 
       if (sourceFeature.hasTag("bridge", "yes")) {

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -131,7 +131,7 @@ public class Roads implements ForwardingProfile.FeatureProcessor, ForwardingProf
 
       if (sourceFeature.hasTag("highway", "motorway_link", "trunk_link", "primary_link", "secondary_link",
         "tertiary_link")) {
-        feat.setAttr("pmap:link", 1).setZoomRange(12, 15);
+        feat.setAttrWithMinzoom("pmap:link", 1, 12);
       }
 
       if (sourceFeature.hasTag("bridge", "yes")) {


### PR DESCRIPTION
@nvkelso I think this is a bug; behavior as-is makes link features vanish z<12, which isn't what we want. Changes the behavior to only add the`pmap:link` tag at 12+.