### PR TITLE
Ensure strait labels are limited to single layer (and not any water polygon exterior rings)

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/PhysicalLine.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/PhysicalLine.java
@@ -18,7 +18,7 @@ public class PhysicalLine implements ForwardingProfile.FeatureProcessor, Forward
   @Override
   public void processFeature(SourceFeature sf, FeatureCollector features) {
     if (sf.canBeLine() && (sf.hasTag("waterway") ||
-      sf.hasTag("natural", "strait", "cliff")) && (!sf.hasTag("waterway", "riverbank", "reservoir"))) {
+      sf.hasTag("natural", "cliff")) && (!sf.hasTag("waterway", "riverbank", "reservoir"))) {
       int minZoom = 12;
       String kind = "other";
       if (sf.hasTag("waterway")) {

--- a/tiles/src/main/java/com/protomaps/basemap/layers/PhysicalLine.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/PhysicalLine.java
@@ -17,7 +17,7 @@ public class PhysicalLine implements ForwardingProfile.FeatureProcessor, Forward
 
   @Override
   public void processFeature(SourceFeature sf, FeatureCollector features) {
-    if (sf.canBeLine() && (sf.hasTag("waterway") ||
+    if (sf.canBeLine() && !sf.canBePolygon() && (sf.hasTag("waterway") ||
       sf.hasTag("natural", "cliff")) && (!sf.hasTag("waterway", "riverbank", "reservoir"))) {
       int minZoom = 12;
       String kind = "other";

--- a/tiles/src/main/java/com/protomaps/basemap/layers/PhysicalPoint.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/PhysicalPoint.java
@@ -96,7 +96,7 @@ public class PhysicalPoint implements ForwardingProfile.FeatureProcessor, Forwar
       sf.canBePolygon() &&
       (sf.hasTag("water") ||
         sf.hasTag("waterway") ||
-        // bay, straight, fjord are included here only (not in water layer) because
+        // bay, strait, fjord are included here only (not in water layer) because
         // OSM treats them as "overlay" label features over the normal water polys
         sf.hasTag("natural", "water", "bay", "strait", "fjord") ||
         sf.hasTag("landuse", "reservoir") ||


### PR DESCRIPTION
Strait features were eligible for both physical_point and physical_line layers, producing duplicate horizontal point labels and oriented line labels in the same tile.

There should only ever be a single representation, and we should prefer the point label at this time. 

(In future we may want to generate curved lines suitable for labeling from the area, but right now we derive a label point instead.)

The result of this change keeps the blue circled node, but drops the red line.

![image](https://github.com/protomaps/basemaps/assets/853051/5dd01825-6ca0-4c63-a88c-dc25adcc754c)
