### PR TITLE
hawaii state routes should not be US interstates

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -36,10 +36,10 @@ public class Roads implements ForwardingProfile.FeatureProcessor, ForwardingProf
       String networkVal = sf.getString("network");
       shieldText = (shieldText == null ? null : shieldText.split(";")[0]);
       if (shieldText != null) {
-        if (shieldText.contains("US ")) {
+        if (shieldText.startsWith("US ")) {
           shieldText = shieldText.replaceAll("US ", "");
           networkVal = "US:US";
-        } else if (shieldText.contains("I ")) {
+        } else if (shieldText.startsWith("I ")) {
           shieldText = shieldText.replaceAll("I ", "");
           networkVal = "US:I";
         } else {


### PR DESCRIPTION
Basic Java string manipulation change.

Fixes #86 