### PR TITLE
introduce Locales; always use US one for highway shields [#86, #92]

### DIFF
--- a/tiles/pom.xml
+++ b/tiles/pom.xml
@@ -10,7 +10,7 @@
     <maven.compiler.source>16</maven.compiler.source>
     <maven.compiler.target>16</maven.compiler.target>
     <planetiler.version>0.6-SNAPSHOT</planetiler.version>
-    <junit.version>5.9.2</junit.version>
+    <junit.version>5.10.0</junit.version>
     <mainClass>com.protomaps.basemap.Basemap</mainClass>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.organization>protomaps</sonar.organization>
@@ -69,6 +69,13 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -25,7 +25,7 @@ public class Roads implements ForwardingProfile.FeatureProcessor, ForwardingProf
   // Hardcoded to US for now
   private CartographicLocale locale = new US();
 
-  public record Shield(String text, String network) {};
+  public record Shield(String text, String network) {}
 
   @Override
   public void processFeature(SourceFeature sf, FeatureCollector features) {

--- a/tiles/src/main/java/com/protomaps/basemap/locales/CartographicLocale.java
+++ b/tiles/src/main/java/com/protomaps/basemap/locales/CartographicLocale.java
@@ -1,0 +1,34 @@
+package com.protomaps.basemap.locales;
+
+import com.onthegomap.planetiler.reader.SourceFeature;
+import com.protomaps.basemap.layers.Roads;
+
+/*
+ * Encapsulates country-specific logic applied to OpenStreetMap tags.
+ * <p>
+ * This is a grab-bag of logic functions for determining output tags in tiled features
+ * based on a spatial join of input features to polygon locales.
+ * CartographicLocale is the parent class that applies to locales outside of any
+ * polygon, locales that are unimplemented, or default behavior when a locale
+ * does not override a method.
+ *
+ * Each implemented locale is named by 2-letter ISO code.
+ */
+public class CartographicLocale {
+
+  protected String strip(String s) {
+    if (s != null) {
+      return s.replaceAll("\\s", "");
+    }
+    return null;
+  }
+
+  public Roads.Shield getShield(SourceFeature sf) {
+    String ref = sf.getString("ref");
+    if (ref != null) {
+      String firstRef = ref.split(";")[0];
+      return new Roads.Shield(strip(firstRef), "other");
+    }
+    return new Roads.Shield(null, null);
+  }
+}

--- a/tiles/src/main/java/com/protomaps/basemap/locales/US.java
+++ b/tiles/src/main/java/com/protomaps/basemap/locales/US.java
@@ -1,0 +1,33 @@
+package com.protomaps.basemap.locales;
+
+import com.onthegomap.planetiler.reader.SourceFeature;
+import com.protomaps.basemap.layers.Roads;
+
+/*
+ * Logic specific to the 50 US states.
+ * <p>
+ * Assigns highway shield text and networks.
+ */
+public class US extends CartographicLocale {
+
+  @Override
+  public Roads.Shield getShield(SourceFeature sf) {
+    String ref = sf.getString("ref");
+    String network = "other";
+
+    if (ref != null) {
+      String firstRef = ref.split(";")[0];
+      String shieldText = firstRef;
+      if (firstRef.startsWith("US ")) {
+        shieldText = firstRef.replaceAll("US ", "");
+        network = "US:US";
+      } else if (firstRef.startsWith("I ")) {
+        shieldText = firstRef.replaceAll("I ", "");
+        network = "US:US_I";
+      }
+      return new Roads.Shield(strip(shieldText), network);
+    }
+
+    return new Roads.Shield(null, null);
+  }
+}

--- a/tiles/src/main/java/com/protomaps/basemap/locales/US.java
+++ b/tiles/src/main/java/com/protomaps/basemap/locales/US.java
@@ -19,10 +19,10 @@ public class US extends CartographicLocale {
       String firstRef = ref.split(";")[0];
       String shieldText = firstRef;
       if (firstRef.startsWith("US ")) {
-        shieldText = firstRef.replaceAll("US ", "");
+        shieldText = firstRef.replace("US ", "");
         network = "US:US";
       } else if (firstRef.startsWith("I ")) {
-        shieldText = firstRef.replaceAll("I ", "");
+        shieldText = firstRef.replace("I ", "");
         network = "US:US_I";
       }
       return new Roads.Shield(strip(shieldText), network);

--- a/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
@@ -12,12 +12,14 @@ class RoadsTest extends LayerTest {
   @Test
   void simple() {
     assertFeatures(12,
-      List.of(Map.of("pmap:kind", "highway", "layer", 1, "pmap:kind_detail", "motorway")),
+      List.of(Map.of("pmap:kind", "highway", "layer", 1, "pmap:kind_detail", "motorway", "ref", "1", "network", "US:US",
+        "shield_text_length", 1)),
       process(SimpleFeature.create(
         newLineString(0, 0, 1, 1),
         new HashMap<>(Map.of(
           "layer", "1",
-          "highway", "motorway"
+          "highway", "motorway",
+          "ref", "US 1"
         )),
         "osm",
         null,

--- a/tiles/src/test/java/com/protomaps/basemap/locales/CartographicLocaleTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/locales/CartographicLocaleTest.java
@@ -8,39 +8,26 @@ import com.onthegomap.planetiler.reader.SimpleFeature;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
-public class CartographicLocaleTest {
+class CartographicLocaleTest {
 
   CartographicLocale locale = new CartographicLocale();
 
-  @Test
-  void shield() {
+  @ParameterizedTest
+  @CsvSource({
+    "A,A,other",
+    "B;A,B,other",
+    "A \t;,A,other"
+  })
+  void shieldUs(String refTag, String expectedRef, String expectedNetwork) {
     var feature = SimpleFeature.create(
       newLineString(0, 0, 1, 1),
-      new HashMap<>(Map.of("ref", "A")));
+      new HashMap<>(Map.of("ref", refTag)));
     var shield = locale.getShield(feature);
-    assertEquals("A", shield.text());
-    assertEquals("other", shield.network());
-  }
-
-  @Test
-  void shieldMultipleRefs() {
-    var feature = SimpleFeature.create(
-      newLineString(0, 0, 1, 1),
-      new HashMap<>(Map.of("ref", "A;B")));
-    var shield = locale.getShield(feature);
-    assertEquals("A", shield.text());
-    assertEquals("other", shield.network());
-  }
-
-  @Test
-  void shieldWhitespace() {
-    var feature = SimpleFeature.create(
-      newLineString(0, 0, 1, 1),
-      new HashMap<>(Map.of("ref", "A \t")));
-    var shield = locale.getShield(feature);
-    assertEquals("A", shield.text());
-    assertEquals("other", shield.network());
+    assertEquals(expectedRef, shield.text());
+    assertEquals(expectedNetwork, shield.network());
   }
 
   @Test

--- a/tiles/src/test/java/com/protomaps/basemap/locales/CartographicLocaleTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/locales/CartographicLocaleTest.java
@@ -1,0 +1,55 @@
+package com.protomaps.basemap.locales;
+
+import static com.onthegomap.planetiler.TestUtils.newLineString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.onthegomap.planetiler.reader.SimpleFeature;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class CartographicLocaleTest {
+
+  CartographicLocale locale = new CartographicLocale();
+
+  @Test
+  void shield() {
+    var feature = SimpleFeature.create(
+      newLineString(0, 0, 1, 1),
+      new HashMap<>(Map.of("ref", "A")));
+    var shield = locale.getShield(feature);
+    assertEquals("A", shield.text());
+    assertEquals("other", shield.network());
+  }
+
+  @Test
+  void shieldMultipleRefs() {
+    var feature = SimpleFeature.create(
+      newLineString(0, 0, 1, 1),
+      new HashMap<>(Map.of("ref", "A;B")));
+    var shield = locale.getShield(feature);
+    assertEquals("A", shield.text());
+    assertEquals("other", shield.network());
+  }
+
+  @Test
+  void shieldWhitespace() {
+    var feature = SimpleFeature.create(
+      newLineString(0, 0, 1, 1),
+      new HashMap<>(Map.of("ref", "A \t")));
+    var shield = locale.getShield(feature);
+    assertEquals("A", shield.text());
+    assertEquals("other", shield.network());
+  }
+
+  @Test
+  void shieldNull() {
+    var feature = SimpleFeature.create(
+      newLineString(0, 0, 1, 1),
+      new HashMap<>(Map.of("network", "irrelevant")));
+    var shield = locale.getShield(feature);
+    assertNull(shield.text());
+    assertNull(shield.network());
+  }
+}

--- a/tiles/src/test/java/com/protomaps/basemap/locales/USTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/locales/USTest.java
@@ -8,58 +8,29 @@ import com.onthegomap.planetiler.reader.SimpleFeature;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
-public class USTest {
+class USTest {
 
   CartographicLocale locale = new US();
 
-  @Test
-  void shieldUs() {
+  @ParameterizedTest
+  @CsvSource({
+    "US 1,1,US:US",
+    "US 1;US 5,1,US:US",
+    "I 5,5,US:US_I",
+    "6,6,other",
+    "US 1 ,1,US:US",
+    "HI-3920,HI-3920,other"
+  })
+  void shieldUs(String refTag, String expectedRef, String expectedNetwork) {
     var feature = SimpleFeature.create(
       newLineString(0, 0, 1, 1),
-      new HashMap<>(Map.of("ref", "US 1")));
+      new HashMap<>(Map.of("ref", refTag)));
     var shield = locale.getShield(feature);
-    assertEquals("1", shield.text());
-    assertEquals("US:US", shield.network());
-  }
-
-  @Test
-  void shieldMultiple() {
-    var feature = SimpleFeature.create(
-      newLineString(0, 0, 1, 1),
-      new HashMap<>(Map.of("ref", "US 1;US 5")));
-    var shield = locale.getShield(feature);
-    assertEquals("1", shield.text());
-    assertEquals("US:US", shield.network());
-  }
-
-  @Test
-  void shieldInterstate() {
-    var feature = SimpleFeature.create(
-      newLineString(0, 0, 1, 1),
-      new HashMap<>(Map.of("ref", "I 5")));
-    var shield = locale.getShield(feature);
-    assertEquals("5", shield.text());
-    assertEquals("US:US_I", shield.network());
-  }
-
-  @Test
-  void shieldOther() {
-    var feature = SimpleFeature.create(
-      newLineString(0, 0, 1, 1),
-      new HashMap<>(Map.of("ref", "6")));
-    var shield = locale.getShield(feature);
-    assertEquals("6", shield.text());
-    assertEquals("other", shield.network());
-  }
-
-  @Test
-  void shieldWhitespace() {
-    var feature = SimpleFeature.create(
-      newLineString(0, 0, 1, 1),
-      new HashMap<>(Map.of("ref", "US 1 ")));
-    var shield = locale.getShield(feature);
-    assertEquals("1", shield.text());
+    assertEquals(expectedRef, shield.text());
+    assertEquals(expectedNetwork, shield.network());
   }
 
   @Test

--- a/tiles/src/test/java/com/protomaps/basemap/locales/USTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/locales/USTest.java
@@ -1,0 +1,74 @@
+package com.protomaps.basemap.locales;
+
+import static com.onthegomap.planetiler.TestUtils.newLineString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.onthegomap.planetiler.reader.SimpleFeature;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class USTest {
+
+  CartographicLocale locale = new US();
+
+  @Test
+  void shieldUs() {
+    var feature = SimpleFeature.create(
+      newLineString(0, 0, 1, 1),
+      new HashMap<>(Map.of("ref", "US 1")));
+    var shield = locale.getShield(feature);
+    assertEquals("1", shield.text());
+    assertEquals("US:US", shield.network());
+  }
+
+  @Test
+  void shieldMultiple() {
+    var feature = SimpleFeature.create(
+      newLineString(0, 0, 1, 1),
+      new HashMap<>(Map.of("ref", "US 1;US 5")));
+    var shield = locale.getShield(feature);
+    assertEquals("1", shield.text());
+    assertEquals("US:US", shield.network());
+  }
+
+  @Test
+  void shieldInterstate() {
+    var feature = SimpleFeature.create(
+      newLineString(0, 0, 1, 1),
+      new HashMap<>(Map.of("ref", "I 5")));
+    var shield = locale.getShield(feature);
+    assertEquals("5", shield.text());
+    assertEquals("US:US_I", shield.network());
+  }
+
+  @Test
+  void shieldOther() {
+    var feature = SimpleFeature.create(
+      newLineString(0, 0, 1, 1),
+      new HashMap<>(Map.of("ref", "6")));
+    var shield = locale.getShield(feature);
+    assertEquals("6", shield.text());
+    assertEquals("other", shield.network());
+  }
+
+  @Test
+  void shieldWhitespace() {
+    var feature = SimpleFeature.create(
+      newLineString(0, 0, 1, 1),
+      new HashMap<>(Map.of("ref", "US 1 ")));
+    var shield = locale.getShield(feature);
+    assertEquals("1", shield.text());
+  }
+
+  @Test
+  void shieldNull() {
+    var feature = SimpleFeature.create(
+      newLineString(0, 0, 1, 1),
+      new HashMap<>(Map.of("network", "irrelevant")));
+    var shield = locale.getShield(feature);
+    assertNull(shield.text());
+    assertNull(shield.network());
+  }
+}


### PR DESCRIPTION
@nvkelso this introduces the `CartographicLocale` class, that isn't dynamic yet (hardcoded to `US`) and adds tests around highway shield and network logic. 