### PR TITLE
Adds bus stops to POIs

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -51,6 +51,7 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
       sf.hasTag("leisure") ||
       sf.hasTag("natural", "beach") ||
       sf.hasTag("railway", "station") ||
+      sf.hasTag("highway", "bus_stop") ||
       sf.hasTag("shop") ||
       sf.hasTag("tourism") &&
         (!sf.hasTag("historic", "district")))) {
@@ -134,6 +135,8 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
           kind = sf.getString("natural");
         } else if (sf.hasTag("railway")) {
           kind = sf.getString("railway");
+        } else if (sf.hasTag("highway")) {
+          kind = sf.getString("highway");
         } else if (sf.hasTag("shop")) {
           kind = sf.getString("shop");
         } else if (sf.hasTag("tourism")) {

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -209,6 +209,10 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
         kindDetail = sf.getString("sport");
       }
 
+      if (sf.hasTag("highway", "bus_stop")) {
+        minZoom = 16;
+      }
+
       // try first for polygon -> point representations
       if (sf.canBePolygon() && sf.hasTag("name") && sf.getString("name") != null) {
         Double wayArea = 0.0;

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -114,6 +114,8 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
       } else if (sf.hasTag("tourism", "attraction", "camp_site", "hotel")) {
         kind = sf.getString("tourism");
         minZoom = 15;
+      } else if (sf.hasTag("highway", "bus_stop")) {
+        minZoom = 18;
       } else {
         // Avoid problem of too many "other" kinds
         // All these will default to min_zoom of 15
@@ -207,10 +209,6 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
         kindDetail = sf.getString("religion");
       } else if (sf.hasTag("sport")) {
         kindDetail = sf.getString("sport");
-      }
-
-      if (sf.hasTag("highway", "bus_stop")) {
-        minZoom = 16;
       }
 
       // try first for polygon -> point representations


### PR DESCRIPTION
This PR fixes #163 by adding `highway=bus_stop` to the POIs

See https://wiki.openstreetmap.org/wiki/Tag:highway%3Dbus_stop