### PR TITLE
Use station tag value in pmap:kind_detail and include tram stops in POIs

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -215,7 +215,7 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
         kindDetail = sf.getString("station");
       }
       
-      if (sf.hasTag("railway", "station") && 
+      if (sf.hasTag("railway", "station") &&
         (!sf.hasTag("station") || sf.hasTag("station", "train", "light_rail", "subway"))) {
         minZoom = 10;
       } else if (sf.hasTag("railway", "halt", "tram_stop")) {

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -52,6 +52,7 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
       sf.hasTag("natural", "beach") ||
       sf.hasTag("railway", "station") ||
       sf.hasTag("railway", "tram_stop") ||
+      sf.hasTag("railway", "halt") ||
       sf.hasTag("shop") ||
       sf.hasTag("tourism") &&
         (!sf.hasTag("historic", "district")))) {
@@ -211,7 +212,7 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
       
       if (sf.hasTag("railway", "station") && (!sf.hasTag("station") || sf.hasTag("station", "train"))) {
         minZoom = 13;
-      if (sf.hasTag("station", "subway", "light_rail")) {
+      } else if (sf.hasTag("station", "subway", "light_rail") || sf.hasTag("railway", "halt")) {
         minZoom = 14;
       } else if (sf.hasTag("railway", "tram_stop")) {
         minZoom = 16;

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -215,7 +215,8 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
         kindDetail = sf.getString("station");
       }
       
-      if (sf.hasTag("railway", "station") && (!sf.hasTag("station") || sf.hasTag("station", "train", "light_rail", "subway"))) {
+      if (sf.hasTag("railway", "station") && 
+        (!sf.hasTag("station") || sf.hasTag("station", "train", "light_rail", "subway"))) {
         minZoom = 10;
       } else if (sf.hasTag("railway", "halt", "tram_stop")) {
         minZoom = 16;

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -208,6 +208,14 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
       } else if (sf.hasTag("station")) {
         kindDetail = sf.getString("station");
       }
+      
+      if (sf.hasTag("railway", "station") && (!sf.hasTag("station") || sf.hasTag("station", "train"))) {
+        minZoom = 13;
+      if (sf.hasTag("station", "subway", "light_rail")) {
+        minZoom = 14;
+      } else if (sf.hasTag("railway", "tram_stop")) {
+        minZoom = 16;
+      }
 
       // try first for polygon -> point representations
       if (sf.canBePolygon() && sf.hasTag("name") && sf.getString("name") != null) {

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -204,6 +204,8 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
         kindDetail = sf.getString("religion");
       } else if (sf.hasTag("sport")) {
         kindDetail = sf.getString("sport");
+      } else if (sf.hasTag("station")) {
+        kindDetail = sf.getString("station");
       }
 
       // try first for polygon -> point representations

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -51,6 +51,7 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
       sf.hasTag("leisure") ||
       sf.hasTag("natural", "beach") ||
       sf.hasTag("railway", "station") ||
+      sf.hasTag("railway", "tram_stop") ||
       sf.hasTag("shop") ||
       sf.hasTag("tourism") &&
         (!sf.hasTag("historic", "district")))) {

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -214,7 +214,7 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
       } else if (sf.hasTag("station")) {
         kindDetail = sf.getString("station");
       }
-      
+
       if (sf.hasTag("railway", "station") &&
         (!sf.hasTag("station") || sf.hasTag("station", "train", "light_rail", "subway"))) {
         minZoom = 10;


### PR DESCRIPTION
Use station tag value in pmap:kind_detail to differentiate subway / light_rail / train stations

Include railway=tram_stop in POIs

This PR fixes #165 

See:
https://wiki.openstreetmap.org/wiki/Key:station
https://wiki.openstreetmap.org/wiki/Tag:railway%3Dtram_stop