### PR TITLE
Replace cdn.protomaps.com fonts with github pages [#41]

### DIFF
--- a/app/src/MapViewComponent.tsx
+++ b/app/src/MapViewComponent.tsx
@@ -77,7 +77,7 @@ function getMaplibreStyle(
   } as StyleSpecification;
   if (!tiles) return style;
   style.layers = [];
-  style.glyphs = "https://cdn.protomaps.com/fonts/pbf/{fontstack}/{range}.pbf";
+  style.glyphs = "https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf";
 
   if (droppedArchive) {
     style.sources = {

--- a/app/src/MapViewComponent.tsx
+++ b/app/src/MapViewComponent.tsx
@@ -77,7 +77,8 @@ function getMaplibreStyle(
   } as StyleSpecification;
   if (!tiles) return style;
   style.layers = [];
-  style.glyphs = "https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf";
+  style.glyphs =
+    "https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf";
 
   if (droppedArchive) {
     style.sources = {

--- a/app/src/VisualTestsComponent.tsx
+++ b/app/src/VisualTestsComponent.tsx
@@ -50,7 +50,7 @@ const createMap = (
       version: 8,
       center: center,
       zoom: zoom,
-      glyphs: "https://cdn.protomaps.com/fonts/pbf/{fontstack}/{range}.pbf",
+      glyphs: "https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf",
       sources: {
         protomaps: {
           type: "vector",

--- a/app/src/VisualTestsComponent.tsx
+++ b/app/src/VisualTestsComponent.tsx
@@ -50,7 +50,8 @@ const createMap = (
       version: 8,
       center: center,
       zoom: zoom,
-      glyphs: "https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf",
+      glyphs:
+        "https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf",
       sources: {
         protomaps: {
           type: "vector",

--- a/styles/src/base_layers.ts
+++ b/styles/src/base_layers.ts
@@ -1631,7 +1631,7 @@ export function labels_layers(source: string, t: Theme): LayerSpecification[] {
       filter: ["all", ["in", "pmap:kind", "river", "stream"]],
       layout: {
         "symbol-placement": "line",
-        "text-font": ["Roboto Regular"],
+        "text-font": ["Sans Regular"],
         "text-field": ["get", "name"],
         "text-size": 12,
         "text-letter-spacing": 0.3,
@@ -1647,7 +1647,7 @@ export function labels_layers(source: string, t: Theme): LayerSpecification[] {
       "source-layer": "physical_point",
       filter: ["any", ["==", "pmap:kind", "peak"]],
       layout: {
-        "text-font": ["Roboto Italic"],
+        "text-font": ["Sans Italic"],
         "text-field": ["get", "name"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 10, 8, 16, 12],
         "text-letter-spacing": 0.1,
@@ -1668,7 +1668,7 @@ export function labels_layers(source: string, t: Theme): LayerSpecification[] {
       layout: {
         "symbol-sort-key": ["get", "pmap:min_zoom"],
         "symbol-placement": "line",
-        "text-font": ["Roboto Regular"],
+        "text-font": ["Sans Regular"],
         "text-field": ["get", "name"],
         "text-size": 12,
       },
@@ -1721,7 +1721,7 @@ export function labels_layers(source: string, t: Theme): LayerSpecification[] {
         ],
       ],
       layout: {
-        "text-font": ["Roboto Medium"],
+        "text-font": ["Sans Medium"],
         "text-field": ["get", "name"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 3, 10, 10, 12],
         "text-letter-spacing": 0.1,
@@ -1739,7 +1739,7 @@ export function labels_layers(source: string, t: Theme): LayerSpecification[] {
       "source-layer": "physical_point",
       filter: ["any", ["in", "pmap:kind", "lake", "water"]],
       layout: {
-        "text-font": ["Roboto Medium"],
+        "text-font": ["Sans Medium"],
         "text-field": ["get", "name"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 3, 0, 6, 12, 10, 12],
         "text-letter-spacing": 0.1,
@@ -1762,7 +1762,7 @@ export function labels_layers(source: string, t: Theme): LayerSpecification[] {
       layout: {
         "symbol-sort-key": ["get", "pmap:min_zoom"],
         "symbol-placement": "line",
-        "text-font": ["Roboto Regular"],
+        "text-font": ["Sans Regular"],
         "text-field": ["get", "name"],
         "text-size": 12,
       },
@@ -1781,7 +1781,7 @@ export function labels_layers(source: string, t: Theme): LayerSpecification[] {
       layout: {
         "symbol-sort-key": ["get", "pmap:min_zoom"],
         "text-field": "{name}",
-        "text-font": ["Roboto Regular"],
+        "text-font": ["Sans Regular"],
         "text-max-width": 7,
         "text-letter-spacing": 0.1,
         "text-padding": [
@@ -1824,7 +1824,7 @@ export function labels_layers(source: string, t: Theme): LayerSpecification[] {
       filter: ["any", ["<", ["get", "pmap:min_zoom"], 13]],
       layout: {
         "symbol-sort-key": ["get", "pmap:min_zoom"],
-        "text-font": ["Roboto Regular"],
+        "text-font": ["Sans Regular"],
         "text-field": ["get", "name"],
         "text-size": 11,
         "text-max-width": 9,
@@ -1876,8 +1876,8 @@ export function labels_layers(source: string, t: Theme): LayerSpecification[] {
         "text-font": [
           "case",
           ["<=", ["get", "pmap:min_zoom"], 5],
-          ["literal", ["Roboto Medium"]],
-          ["literal", ["Roboto Regular"]],
+          ["literal", ["Sans Medium"]],
+          ["literal", ["Sans Regular"]],
         ],
         "text-padding": [
           "interpolate",
@@ -1988,7 +1988,7 @@ export function labels_layers(source: string, t: Theme): LayerSpecification[] {
           5,
           ["get", "name"],
         ],
-        "text-font": ["Roboto Regular"],
+        "text-font": ["Sans Regular"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 3, 11, 7, 24],
         "text-radial-offset": 0.2,
         "text-anchor": "center",
@@ -2009,7 +2009,7 @@ export function labels_layers(source: string, t: Theme): LayerSpecification[] {
       layout: {
         "symbol-sort-key": ["get", "pmap:min_zoom"],
         "text-field": "{name}",
-        "text-font": ["Roboto Medium"],
+        "text-font": ["Sans Medium"],
         "text-size": [
           "interpolate",
           ["linear"],


### PR DESCRIPTION
* refer to a font by a thematic name like Sans instead of the font name
* the specific font used is an implementation detail
* fonts are not versioned
* replaces Roboto latin with Noto for now, as we transition to final design choices