### PR TITLE
bus_stop zoom off by 1 [#163]

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -523,7 +523,7 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
           .setAttr("cuisine", sf.getString("cuisine"))
           .setAttr("religion", sf.getString("religion"))
           .setAttr("sport", sf.getString("sport"))
-          .setZoomRange(minZoom, 15)
+          .setZoomRange(Math.min(minZoom,15), 15)
           .setBufferPixels(128);
 
         // Core Tilezen schema properties

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -115,7 +115,7 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
         kind = sf.getString("tourism");
         minZoom = 15;
       } else if (sf.hasTag("highway", "bus_stop")) {
-        minZoom = 18;
+        minZoom = 17;
       } else {
         // Avoid problem of too many "other" kinds
         // All these will default to min_zoom of 15
@@ -523,7 +523,7 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
           .setAttr("cuisine", sf.getString("cuisine"))
           .setAttr("religion", sf.getString("religion"))
           .setAttr("sport", sf.getString("sport"))
-          .setZoomRange(Math.min(minZoom,15), 15)
+          .setZoomRange(Math.min(minZoom, 15), 15)
           .setBufferPixels(128);
 
         // Core Tilezen schema properties


### PR DESCRIPTION
@nvkelso @eikes 

We should document how this works at https://docs.protomaps.com/basemaps/layers 

notably, we need to be consistent about the mismatch between 256px NE/Leaflet zooms and MapLibre zooms. when we want bus stops to display at Z18 (MapLibre) we encode min_zoom = 17 in the tiles?