### PR TITLE
Only use ne_10m scale for boundaries [#119]

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Boundaries.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Boundaries.java
@@ -30,13 +30,7 @@ public class Boundaries implements ForwardingProfile.OsmRelationPreprocessor, Fo
     var themeMinZoom = 0;
     var themeMaxZoom = 0;
 
-    if (sourceLayer.equals("ne_50m_admin_0_boundary_lines_land") ||
-      sourceLayer.equals("ne_50m_admin_0_boundary_lines_disputed_areas") ||
-      sourceLayer.equals("ne_50m_admin_1_states_provinces_lines")) {
-      themeMinZoom = 1;
-      themeMaxZoom = 3;
-      kind = "tz_boundary";
-    } else if (sourceLayer.equals("ne_10m_admin_0_boundary_lines_land") ||
+    if (sourceLayer.equals("ne_10m_admin_0_boundary_lines_land") ||
       sourceLayer.equals("ne_10m_admin_0_boundary_lines_map_units") ||
       sourceLayer.equals("ne_10m_admin_0_boundary_lines_disputed_areas") ||
       sourceLayer.equals("ne_10m_admin_1_states_provinces_lines")) {


### PR DESCRIPTION
* We do our own generalization in code, so we don't need the generalized tables.

Fixes duplicate boundaries where multiple ne versions don't match up @nvkelso 

Before: (exaggerated overzoom)

<img width="496" alt="Screenshot 2023-11-10 at 07 32 22" src="https://github.com/protomaps/basemaps/assets/77501/86a6dc6b-177c-4c78-8b7c-836de2aac812">

After:

<img width="538" alt="Screenshot 2023-11-10 at 07 33 10" src="https://github.com/protomaps/basemaps/assets/77501/4fecfe1f-af62-4fa0-95b0-b5c61413e1f1">



