### PR TITLE
don't require man_made=bridge outlines have area=yes [#180]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Tiles v3.0.1
+------
+- Fix pedestrian bridge areas
+
 Styles v2.0.0-alpha.4
 ------
 - Fix ordering issues related to pedestrian bridges.
@@ -6,6 +10,10 @@ Tiles v3.0.0-pre4
 ------
 - Fix appearance of NE boundaries at low zooms.
 - Add `pmap:kind`=`bus_stop` to POIs. via [@eikes](https://github.com/eikes)
+
+Tiles v3.0.0-pre3
+------
+- Make `disputed` tag on boundaries consistent [#190]
 
 v3.0.0-pre1
 ------

--- a/app/src/examples.json
+++ b/app/src/examples.json
@@ -2,14 +2,14 @@
   {
     "name": "taiwan-z8",
     "description": "Compare the appearance of highways",
-    "tags": ["highway", "cjk"],
+    "tags": ["highway", "cjk", "tw"],
     "center": [121.333, 24.32],
     "zoom": 8
   },
   {
     "name": "taiwan-z16-buildings",
     "description": "Compare the appearance of buildings",
-    "tags": ["buildings", "cjk"],
+    "tags": ["building", "cjk", "tw"],
     "center": [121.4818, 25.0271],
     "zoom": 16
   },
@@ -26,5 +26,12 @@
     "tags": [],
     "center": [0, 0],
     "zoom": 2
+  },
+  {
+    "name": "zurich-bridges",
+    "description": "Pedestrian bridge tagged as area",
+    "tags": ["bridge", "ch"],
+    "center": [8.54252, 47.376925],
+    "zoom": 17
   }
 ]

--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -92,7 +92,7 @@ public class Basemap extends ForwardingProfile {
 
   @Override
   public String version() {
-    return "3.0.0-pre3";
+    return "3.0.1";
   }
 
   @Override

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
@@ -21,7 +21,7 @@ public class Landuse implements ForwardingProfile.FeatureProcessor, ForwardingPr
       sf.hasTag("landuse", "recreation_ground", "industrial", "brownfield", "railway", "cemetery", "commercial",
         "grass", "orchard", "farmland", "farmyard", "residential", "military") ||
       sf.hasTag("leisure", "park", "garden", "golf_course", "dog_park", "playground", "pitch", "nature_reserve") ||
-      sf.hasTag("man_made", "pier") || sf.hasTag("man_made", "bridge") ||
+      sf.hasTag("man_made", "pier", "bridge") ||
       sf.hasTag("natural", "beach") ||
       // TODO: (nvkelso 20230622) This use of the place tag here is dubious, though paired with "residential"
       sf.hasTag("place", "neighbourhood") ||

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
@@ -21,14 +21,14 @@ public class Landuse implements ForwardingProfile.FeatureProcessor, ForwardingPr
       sf.hasTag("landuse", "recreation_ground", "industrial", "brownfield", "railway", "cemetery", "commercial",
         "grass", "orchard", "farmland", "farmyard", "residential", "military") ||
       sf.hasTag("leisure", "park", "garden", "golf_course", "dog_park", "playground", "pitch", "nature_reserve") ||
-      sf.hasTag("man_made", "pier") ||
+      sf.hasTag("man_made", "pier") || sf.hasTag("man_made", "bridge") ||
       sf.hasTag("natural", "beach") ||
       // TODO: (nvkelso 20230622) This use of the place tag here is dubious, though paired with "residential"
       sf.hasTag("place", "neighbourhood") ||
       sf.hasTag("railway", "platform") ||
       sf.hasTag("tourism", "zoo") ||
       (sf.hasTag("area", "yes") &&
-        (sf.hasTag("highway", "pedestrian", "footway") || sf.hasTag("man_made", "bridge"))))) {
+        (sf.hasTag("highway", "pedestrian", "footway"))))) {
       String kind = "other";
       if (sf.hasTag("aeroway", "aerodrome")) {
         kind = sf.getString("aeroway");


### PR DESCRIPTION
See #180 

Refer to https://wiki.openstreetmap.org/wiki/Tag:man_made%3Dbridge : 

> The tag [man_made](https://wiki.openstreetmap.org/wiki/Key:man_made)=bridge is used to tag a bridge defined by the outline of the bridge.

@wipfli @nvkelso 