### PR TITLE
POI layers in tiles is deterministic

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -13,7 +13,6 @@ import com.protomaps.basemap.feature.FeatureId;
 import com.protomaps.basemap.feature.QrankDb;
 import com.protomaps.basemap.names.OsmNames;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfile.FeaturePostProcessor {
 
@@ -31,13 +30,6 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
   private static final double WORLD_AREA_FOR_70K_SQUARE_METERS =
     Math.pow(GeoUtils.metersToPixelAtEquator(0, Math.sqrt(70_000)) / 256d, 2);
   private static final double LOG2 = Math.log(2);
-
-  /*
-   * Assign every toilet a monotonically increasing ID so that we can limit output at low zoom levels to only the
-   * highest ID toilet nodes. Be sure to use thread-safe data structures any time a profile holds state since multiple
-   * threads invoke processFeature concurrently.
-   */
-  private final AtomicInteger poiNumber = new AtomicInteger(0);
 
   @Override
   public void processFeature(SourceFeature sf, FeatureCollector features) {
@@ -482,7 +474,7 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
 
         // Server sort features so client label collisions are pre-sorted
         // NOTE: (nvkelso 20230627) This could also include other params like the name
-        polyLabelPosition.setSortKey(minZoom * 1000 + poiNumber.incrementAndGet());
+        polyLabelPosition.setSortKey(minZoom * 1000);
 
         // Even with the categorical zoom bucketing above, we end up with too dense a point feature spread in downtown
         // areas, so cull the labels which wouldn't label at earlier zooms than the max_zoom of 15
@@ -567,7 +559,7 @@ public class Pois implements ForwardingProfile.FeatureProcessor, ForwardingProfi
 
         // Server sort features so client label collisions are pre-sorted
         // NOTE: (nvkelso 20230627) This could also include other params like the name
-        pointFeature.setSortKey(minZoom * 1000 + poiNumber.incrementAndGet());
+        pointFeature.setSortKey(minZoom * 1000);
 
         // Even with the categorical zoom bucketing above, we end up with too dense a point feature spread in downtown
         // areas, so cull the labels which wouldn't label at earlier zooms than the max_zoom of 15


### PR DESCRIPTION
* remove auto-incrementing integer as part of sort key

@nvkelso we need this to make the build byte-to-byte identical on the same inputs. The consistent sorting of ties should be handled internally. 