### PR TITLE
Simplify code and remove area filter for water features [#198]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Tiles v3.3.0
+------
+- Improve water generalization detail by doing area filtering post-merge [#198]
+
 Tiles v3.2.0
 ------
 - Add `village_green` and `allotments` to landuse layer via @lenalebt [#206]

--- a/app/src/examples.json
+++ b/app/src/examples.json
@@ -47,5 +47,19 @@
     "tags": ["boundaries"],
     "center": [37.382, -1.592],
     "zoom": 7
+  },
+  {
+    "name": "colombia-rivers",
+    "description": "water features west of Bogota should not be broken",
+    "tags": ["water"],
+    "center": [-74.422,4.62],
+    "zoom": 7.8
+  },
+  {
+    "name": "river-thames",
+    "description": "River Thames should not have pieces missing",
+    "tags": ["water"],
+    "center": [-0.3,51.4],
+    "zoom": 8.9
   }
 ]

--- a/app/src/examples.json
+++ b/app/src/examples.json
@@ -52,14 +52,14 @@
     "name": "colombia-rivers",
     "description": "water features west of Bogota should not be broken",
     "tags": ["water"],
-    "center": [-74.422,4.62],
+    "center": [-74.422, 4.62],
     "zoom": 7.8
   },
   {
     "name": "river-thames",
     "description": "River Thames should not have pieces missing",
     "tags": ["water"],
-    "center": [-0.3,51.4],
+    "center": [-0.3, 51.4],
     "zoom": 8.9
   }
 ]

--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -92,7 +92,7 @@ public class Basemap extends ForwardingProfile {
 
   @Override
   public String version() {
-    return "3.2.0";
+    return "3.3.0";
   }
 
   @Override

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -7,7 +7,6 @@ import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.reader.SourceFeature;
 import com.onthegomap.planetiler.util.Parse;
-import com.protomaps.basemap.postprocess.Area;
 import java.util.List;
 
 public class Water implements ForwardingProfile.FeatureProcessor, ForwardingProfile.FeaturePostProcessor {

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -144,7 +144,7 @@ public class Water implements ForwardingProfile.FeatureProcessor, ForwardingProf
         .setAttr("water", sf.getString("water"))
         .setAttr("waterway", sf.getString("waterway"))
         .setZoomRange(6, 15)
-        .setMinPixelSize(3.0)
+        .setMinPixelSize(1.0)
         .setBufferPixels(8);
 
       // Core Tilezen schema properties
@@ -168,16 +168,6 @@ public class Water implements ForwardingProfile.FeatureProcessor, ForwardingProf
 
   @Override
   public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) throws GeometryException {
-    if (zoom == 15)
-      return items;
-
-    int minArea = 400 / (4096 * 4096) * (256 * 256);
-    if (zoom == 6)
-      minArea = 600 / (4096 * 4096) * (256 * 256);
-    else if (zoom <= 5)
-      minArea = 800 / (4096 * 4096) * (256 * 256);
-    items = Area.filterArea(items, minArea);
-
     return FeatureMerge.mergeOverlappingPolygons(items, 1);
   }
 }


### PR DESCRIPTION
We can't do any pre-filtering of water areas, because sometimes they are parts of linear features. Let the polygon merge routine do its work, and change the threshold to 1.0 pixels.
