### PR TITLE
fix #200 generalize boundaries line features

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Boundaries.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Boundaries.java
@@ -276,10 +276,15 @@ public class Boundaries implements ForwardingProfile.OsmRelationPreprocessor, Fo
 
   @Override
   public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) {
+    var tolerance = 0.4;
+    if( zoom < 6 ) {
+      tolerance = 0.2;
+    }
     return FeatureMerge.mergeLineStrings(items,
       0.0,
-      0.1,
-      4
+      tolerance,
+      4,
+      true
     );
   }
 

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Boundaries.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Boundaries.java
@@ -277,7 +277,7 @@ public class Boundaries implements ForwardingProfile.OsmRelationPreprocessor, Fo
   @Override
   public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) {
     var tolerance = 0.4;
-    if( zoom < 6 ) {
+    if (zoom < 6) {
       tolerance = 0.2;
     }
     return FeatureMerge.mergeLineStrings(items,


### PR DESCRIPTION
Fixes #200.

OSM boundaries were quite detailed at mid- and high-zooms, and NE boundaries were a bit too detailed at low zooms.

Solution is to variably adjust the pixel tolerance from 0.1 to 0.4 to reduce file size and visual complexity, while preserving some details on fractional zoom in.

After:
<img width="1646" alt="Screenshot 2024-03-25 at 1 33 51 PM" src="https://github.com/protomaps/basemaps/assets/853051/0ae9961b-8597-453b-a354-f3316bc74d05">

Before:
<img width="1646" alt="Screenshot 2024-03-25 at 1 29 18 PM" src="https://github.com/protomaps/basemaps/assets/853051/fdc0816f-13a7-4729-b3de-849549bbcd41">