### PR TITLE
add daylight landcover to tileset [#154]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Tiles v3.5.0
+------
+- Add Daylight Landcover from zooms 0-7. [#154]
+
 Tiles v3.4.1
 ------
 - Improve boundaries generalization [#200]

--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -9,6 +9,7 @@ import com.protomaps.basemap.layers.Boundaries;
 import com.protomaps.basemap.layers.Buildings;
 import com.protomaps.basemap.layers.Earth;
 import com.protomaps.basemap.layers.Landuse;
+import com.protomaps.basemap.layers.Landcover;
 import com.protomaps.basemap.layers.Natural;
 import com.protomaps.basemap.layers.PhysicalLine;
 import com.protomaps.basemap.layers.PhysicalPoint;
@@ -36,6 +37,10 @@ public class Basemap extends ForwardingProfile {
     var landuse = new Landuse();
     registerHandler(landuse);
     registerSourceHandler("osm", landuse);
+
+    var landcover = new Landcover();
+    registerHandler(landcover);
+    registerSourceHandler("landcover", landcover::processLandcover);
 
     var natural = new Natural();
     registerHandler(natural);
@@ -127,7 +132,8 @@ public class Basemap extends ForwardingProfile {
       .addShapefileSource("osm_water", sourcesDir.resolve("water-polygons-split-3857.zip"),
         "https://osmdata.openstreetmap.de/download/water-polygons-split-3857.zip")
       .addShapefileSource("osm_land", sourcesDir.resolve("land-polygons-split-3857.zip"),
-        "https://osmdata.openstreetmap.de/download/land-polygons-split-3857.zip");
+        "https://osmdata.openstreetmap.de/download/land-polygons-split-3857.zip")
+      .addGeoPackageSource("landcover", sourcesDir.resolve("daylight-landcover.gpkg"), "https://r2-public.protomaps.com/datasets/daylight-landcover.gpkg");
 
     //    Downloader.create(planetiler.config()).add("ne", neUrl, nePath)
     //      .add("qrank", "https://qrank.wmcloud.org/download/qrank.csv.gz", sourcesDir.resolve("qrank.csv.gz")).run();

--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -8,8 +8,8 @@ import com.protomaps.basemap.feature.QrankDb;
 import com.protomaps.basemap.layers.Boundaries;
 import com.protomaps.basemap.layers.Buildings;
 import com.protomaps.basemap.layers.Earth;
-import com.protomaps.basemap.layers.Landuse;
 import com.protomaps.basemap.layers.Landcover;
+import com.protomaps.basemap.layers.Landuse;
 import com.protomaps.basemap.layers.Natural;
 import com.protomaps.basemap.layers.PhysicalLine;
 import com.protomaps.basemap.layers.PhysicalPoint;
@@ -133,7 +133,8 @@ public class Basemap extends ForwardingProfile {
         "https://osmdata.openstreetmap.de/download/water-polygons-split-3857.zip")
       .addShapefileSource("osm_land", sourcesDir.resolve("land-polygons-split-3857.zip"),
         "https://osmdata.openstreetmap.de/download/land-polygons-split-3857.zip")
-      .addGeoPackageSource("landcover", sourcesDir.resolve("daylight-landcover.gpkg"), "https://r2-public.protomaps.com/datasets/daylight-landcover.gpkg");
+      .addGeoPackageSource("landcover", sourcesDir.resolve("daylight-landcover.gpkg"),
+        "https://r2-public.protomaps.com/datasets/daylight-landcover.gpkg");
 
     //    Downloader.create(planetiler.config()).add("ne", neUrl, nePath)
     //      .add("qrank", "https://qrank.wmcloud.org/download/qrank.csv.gz", sourcesDir.resolve("qrank.csv.gz")).run();

--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -96,7 +96,7 @@ public class Basemap extends ForwardingProfile {
 
   @Override
   public String version() {
-    return "3.4.1";
+    return "3.5.0";
   }
 
   @Override

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
@@ -6,19 +6,24 @@ import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.reader.SourceFeature;
 import com.protomaps.basemap.feature.FeatureId;
-
 import java.util.List;
 
 public class Landcover implements ForwardingProfile.FeaturePostProcessor {
 
   public void processLandcover(SourceFeature sf, FeatureCollector features) {
     String kind = sf.getString("class");
-    if (kind.equals("urban")) kind = "urban_area";
-    if (kind.equals("crop")) kind = "farmland";
-    if (kind.equals("grass")) kind = "grassland";
-    if (kind.equals("trees")) kind = "forest";
-    if (kind.equals("snow")) kind = "glacier";
-    if (kind.equals("shrub")) kind = "scrub";
+    if (kind.equals("urban"))
+      kind = "urban_area";
+    if (kind.equals("crop"))
+      kind = "farmland";
+    if (kind.equals("grass"))
+      kind = "grassland";
+    if (kind.equals("trees"))
+      kind = "forest";
+    if (kind.equals("snow"))
+      kind = "glacier";
+    if (kind.equals("shrub"))
+      kind = "scrub";
     // barren is passed through
 
     features.polygon(this.name())

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 public class Landcover implements ForwardingProfile.FeaturePostProcessor {
 
-  final static Map<String, String> kindMapping = Map.of("urban", "urban_area", "crop", "farmland", "grass", "grassland",
+  static final Map<String, String> kindMapping = Map.of("urban", "urban_area", "crop", "farmland", "grass", "grassland",
     "trees", "forest", "snow", "glacier", "shrub", "scrub", "barren", "barren");
 
   public void processLandcover(SourceFeature sf, FeatureCollector features) {

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
@@ -30,6 +30,7 @@ public class Landcover implements ForwardingProfile.FeaturePostProcessor {
         break;
       case "shrub":
         kind = "scrub";
+        break;
       default:
         break;
     }

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
@@ -7,33 +7,15 @@ import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.reader.SourceFeature;
 import com.protomaps.basemap.feature.FeatureId;
 import java.util.List;
+import java.util.Map;
 
 public class Landcover implements ForwardingProfile.FeaturePostProcessor {
 
+  final static Map<String, String> kindMapping = Map.of("urban", "urban_area", "crop", "farmland", "grass", "grassland",
+    "trees", "forest", "snow", "glacier", "shrub", "scrub", "barren", "barren");
+
   public void processLandcover(SourceFeature sf, FeatureCollector features) {
-    String kind = sf.getString("class");
-    switch (kind) {
-      case "urban":
-        kind = "urban_area";
-        break;
-      case "crop":
-        kind = "farmland";
-        break;
-      case "grass":
-        kind = "grassland";
-        break;
-      case "trees":
-        kind = "forest";
-        break;
-      case "snow":
-        kind = "glacier";
-        break;
-      case "shrub":
-        kind = "scrub";
-        break;
-      default:
-        break;
-    }
+    String kind = kindMapping.getOrDefault(sf.getString("class"), "unknown");
 
     features.polygon(this.name())
       .setId(FeatureId.create(sf))

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
@@ -24,7 +24,6 @@ public class Landcover implements ForwardingProfile.FeaturePostProcessor {
       kind = "glacier";
     if (kind.equals("shrub"))
       kind = "scrub";
-    // barren is passed through
 
     features.polygon(this.name())
       .setId(FeatureId.create(sf))

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
@@ -12,18 +12,25 @@ public class Landcover implements ForwardingProfile.FeaturePostProcessor {
 
   public void processLandcover(SourceFeature sf, FeatureCollector features) {
     String kind = sf.getString("class");
-    if (kind.equals("urban"))
-      kind = "urban_area";
-    if (kind.equals("crop"))
-      kind = "farmland";
-    if (kind.equals("grass"))
-      kind = "grassland";
-    if (kind.equals("trees"))
-      kind = "forest";
-    if (kind.equals("snow"))
-      kind = "glacier";
-    if (kind.equals("shrub"))
-      kind = "scrub";
+    switch (kind) {
+      case "urban":
+        kind = "urban_area";
+        break;
+      case "crop":
+        kind = "farmland";
+        break;
+      case "grass":
+        kind = "grassland";
+        break;
+      case "trees":
+        kind = "forest";
+        break;
+      case "snow":
+        kind = "glacier";
+        break;
+      case "shrub":
+        kind = "scrub";
+    }
 
     features.polygon(this.name())
       .setId(FeatureId.create(sf))

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
@@ -30,6 +30,8 @@ public class Landcover implements ForwardingProfile.FeaturePostProcessor {
         break;
       case "shrub":
         kind = "scrub";
+      default:
+        break;
     }
 
     features.polygon(this.name())

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
@@ -1,0 +1,40 @@
+package com.protomaps.basemap.layers;
+
+import com.onthegomap.planetiler.FeatureCollector;
+import com.onthegomap.planetiler.ForwardingProfile;
+import com.onthegomap.planetiler.VectorTile;
+import com.onthegomap.planetiler.geo.GeometryException;
+import com.onthegomap.planetiler.reader.SourceFeature;
+import com.protomaps.basemap.feature.FeatureId;
+
+import java.util.List;
+
+public class Landcover implements ForwardingProfile.FeaturePostProcessor {
+
+  public void processLandcover(SourceFeature sf, FeatureCollector features) {
+    String kind = sf.getString("class");
+    if (kind.equals("urban")) kind = "urban_area";
+    if (kind.equals("crop")) kind = "farmland";
+    if (kind.equals("grass")) kind = "grassland";
+    if (kind.equals("trees")) kind = "forest";
+    if (kind.equals("snow")) kind = "glacier";
+    if (kind.equals("shrub")) kind = "scrub";
+    // barren is passed through
+
+    features.polygon(this.name())
+      .setId(FeatureId.create(sf))
+      .setAttr("pmap:kind", kind)
+      .setZoomRange(0, 7)
+      .setMinPixelSize(0.0);
+  }
+
+  @Override
+  public String name() {
+    return "landcover";
+  }
+
+  @Override
+  public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) throws GeometryException {
+    return items;
+  }
+}

--- a/tiles/src/test/java/com/protomaps/basemap/layers/LandcoverTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/LandcoverTest.java
@@ -1,0 +1,35 @@
+package com.protomaps.basemap.layers;
+
+import static com.onthegomap.planetiler.TestUtils.newPolygon;
+
+import com.onthegomap.planetiler.reader.SimpleFeature;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class LandcoverTest extends LayerTest {
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "urban,urban_area",
+    "crop,farmland",
+    "grass,grassland",
+    "trees,forest",
+    "snow,glacier",
+    "shrub,scrub",
+    "barren,barren"
+  })
+  void simple(String daylightClassString, String expectedString) {
+    assertFeatures(7,
+      List.of(Map.of("pmap:kind", expectedString)),
+      process(SimpleFeature.create(
+        newPolygon(0, 0, 0, 1, 1, 1, 0, 0),
+        new HashMap<>(Map.of("class", daylightClassString)),
+        "landcover",
+        null,
+        0
+      )));
+  }
+}

--- a/tiles/src/test/java/com/protomaps/basemap/layers/LandcoverTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/LandcoverTest.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-public class LandcoverTest extends LayerTest {
+class LandcoverTest extends LayerTest {
 
   @ParameterizedTest
   @CsvSource(value = {


### PR DESCRIPTION
Connects with https://github.com/protomaps/basemaps/issues/154.

* Use geopackage mirror of daylight dataset from https://daylightmap.org/2023/10/11/landcover.html
* remap daylight classes to tilezen-like kinds
