### PR TITLE
Allow passing custom themes to create layers

### DIFF
--- a/styles/.gitignore
+++ b/styles/.gitignore
@@ -1,1 +1,2 @@
 dist
+node_modules

--- a/styles/src/index.ts
+++ b/styles/src/index.ts
@@ -17,19 +17,34 @@ export function labels(source: string, key: string): LayerSpecification[] {
   return labels_layers(source, theme);
 }
 
-export function layersWithCustomTheme(source: string, theme: Theme): LayerSpecification[] {
+export function layersWithCustomTheme(
+  source: string,
+  theme: Theme,
+): LayerSpecification[] {
   return nolabels_layers(source, theme).concat(labels_layers(source, theme));
 }
 
-export function layersWithPartialCustomTheme(source: string, key: string, partialTheme: Partial<Theme>): LayerSpecification[] {
+export function layersWithPartialCustomTheme(
+  source: string,
+  key: string,
+  partialTheme: Partial<Theme>,
+): LayerSpecification[] {
   const mergedTheme = { ...themes[key], ...partialTheme };
-  return nolabels_layers(source, mergedTheme).concat(labels_layers(source, mergedTheme));
+  return nolabels_layers(source, mergedTheme).concat(
+    labels_layers(source, mergedTheme),
+  );
 }
 
-export function noLabelsWithCustomTheme(source: string, theme: Theme): LayerSpecification[] {
+export function noLabelsWithCustomTheme(
+  source: string,
+  theme: Theme,
+): LayerSpecification[] {
   return nolabels_layers(source, theme);
 }
 
-export function labelsWithCustomTheme(source: string, theme: Theme): LayerSpecification[] {
+export function labelsWithCustomTheme(
+  source: string,
+  theme: Theme,
+): LayerSpecification[] {
   return labels_layers(source, theme);
 }

--- a/styles/src/index.ts
+++ b/styles/src/index.ts
@@ -1,6 +1,6 @@
 import { LayerSpecification } from "@maplibre/maplibre-gl-style-spec";
 import { labels_layers, nolabels_layers } from "./base_layers";
-import themes from "./themes";
+import themes, { Theme } from "./themes";
 
 export default function (source: string, key: string): LayerSpecification[] {
   const theme = themes[key];
@@ -14,5 +14,22 @@ export function noLabels(source: string, key: string): LayerSpecification[] {
 
 export function labels(source: string, key: string): LayerSpecification[] {
   const theme = themes[key];
+  return labels_layers(source, theme);
+}
+
+export function layersWithCustomTheme(source: string, theme: Theme): LayerSpecification[] {
+  return nolabels_layers(source, theme).concat(labels_layers(source, theme));
+}
+
+export function layersWithPartialCustomTheme(source: string, key: string, partialTheme: Partial<Theme>): LayerSpecification[] {
+  const mergedTheme = { ...themes[key], ...partialTheme };
+  return nolabels_layers(source, mergedTheme).concat(labels_layers(source, mergedTheme));
+}
+
+export function noLabelsWithCustomTheme(source: string, theme: Theme): LayerSpecification[] {
+  return nolabels_layers(source, theme);
+}
+
+export function labelsWithCustomTheme(source: string, theme: Theme): LayerSpecification[] {
   return labels_layers(source, theme);
 }

--- a/styles/test/custom_themes.test.ts
+++ b/styles/test/custom_themes.test.ts
@@ -18,7 +18,7 @@ const STUB = {
 };
 
 test("validate custom themes", () => {
-  const customTheme = themes["dark"];
+  const customTheme = themes.dark;
   STUB.layers = labelsWithCustomTheme("sourcename", customTheme);
   const errors = validateStyleMin(STUB);
   assert.deepStrictEqual([], errors);
@@ -30,12 +30,11 @@ test("validate layers with partial custom theme overrides", () => {
   STUB.layers = layersWithPartialCustomTheme(
     "sourcename",
     "dark",
-    partialTheme
+    partialTheme,
   );
   const errors = validateStyleMin(STUB);
   assert.deepStrictEqual([], errors);
-  assert.deepStrictEqual(
-    STUB.layers.find((l) => l.id == "background")["paint"],
-    { "background-color": customBackgroundColor }
-  );
+  assert.deepStrictEqual(STUB.layers.find((l) => l.id === "background").paint, {
+    "background-color": customBackgroundColor,
+  });
 });

--- a/styles/test/custom_themes.test.ts
+++ b/styles/test/custom_themes.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert";
+import { test } from "node:test";
+import { validateStyleMin } from "@maplibre/maplibre-gl-style-spec";
+import {
+  labelsWithCustomTheme,
+  layersWithPartialCustomTheme,
+} from "../src/index";
+import themes from "../src/themes";
+
+const STUB = {
+  version: 8,
+  glyphs: "https://example.com/{fontstack}/{range}.pbf",
+  sources: {
+    sourcename: {
+      type: "vector",
+    },
+  },
+};
+
+test("validate custom themes", () => {
+  const customTheme = themes["dark"];
+  STUB.layers = labelsWithCustomTheme("sourcename", customTheme);
+  const errors = validateStyleMin(STUB);
+  assert.deepStrictEqual([], errors);
+});
+
+test("validate layers with partial custom theme overrides", () => {
+  const customBackgroundColor = "#fff";
+  const partialTheme = { background: customBackgroundColor };
+  STUB.layers = layersWithPartialCustomTheme(
+    "sourcename",
+    "dark",
+    partialTheme
+  );
+  const errors = validateStyleMin(STUB);
+  assert.deepStrictEqual([], errors);
+  assert.deepStrictEqual(
+    STUB.layers.find((l) => l.id == "background")["paint"],
+    { "background-color": customBackgroundColor }
+  );
+});

--- a/styles/test/index.test.ts
+++ b/styles/test/index.test.ts
@@ -6,6 +6,7 @@ import themes from "../src/themes";
 
 import "./base_layers.test";
 import "./themes.test";
+import "./custom_themes.test"
 
 const STUB = {
   version: 8,

--- a/styles/test/index.test.ts
+++ b/styles/test/index.test.ts
@@ -5,8 +5,8 @@ import layers from "../src/index";
 import themes from "../src/themes";
 
 import "./base_layers.test";
+import "./custom_themes.test";
 import "./themes.test";
-import "./custom_themes.test"
 
 const STUB = {
   version: 8,


### PR DESCRIPTION
So far it was only possible to generate styles based on a set of fixed themes maintained by the protomaps project.

With this change, it is possible to pass a custom colour theme to create layers, without interfering with the final style. Also passing partial themes is possible to override only a small set of properties.

Example:

```ts
const myCustomTheme: Theme = {...}
const style = layersWithCustomTheme("protomaps", myCustomTheme)
```
or
```ts
const partialTheme: Partial<Theme> = { background: "#fff" };
const style = layersWithPartialCustomTheme(
    "protomaps",
    "dark", // use dark theme as base
    partialTheme
);
```

Related issue: https://github.com/protomaps/basemaps/issues/224

This is just my take on addressing this problem. Please let me know if you have any suggestions or if you think some of these changes aren't necessary. And feel free to edit or rename anything.

Thanks :)