### PR TITLE
add missing "locality" places

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
@@ -152,7 +152,8 @@ public class Places implements ForwardingProfile.FeaturePostProcessor {
 
   public void processOsm(SourceFeature sf, FeatureCollector features) {
     if (sf.isPoint() && sf.hasTag("name") &&
-      (sf.hasTag("place", "suburb", "town", "village", "neighbourhood", "quarter", "city", "country", "state",
+      (sf.hasTag("place", "suburb", "town", "village", "locality", "hamlet",
+        "isolated_dwelling", "farm", "allotments", "neighbourhood", "quarter", "city", "country", "state",
         "province"))) {
       String kind = "other";
       int kindRank = 6;
@@ -184,7 +185,6 @@ public class Places implements ForwardingProfile.FeaturePostProcessor {
             minZoom = neAdmin0.minLabel() - NE_ZOOM_OFFSET;
             maxZoom = neAdmin0.maxLabel() - NE_ZOOM_OFFSET;
           }
-
           kindRank = 0;
           break;
         case "state":
@@ -210,7 +210,9 @@ public class Places implements ForwardingProfile.FeaturePostProcessor {
           maxZoom = 15.0f;
           kindRank = 2;
           if (population == 0) {
+            minZoom = 8.0f;
             if (place.equals("town")) {
+              minZoom = 9.0f;
               population = 10000;
             } else {
               population = 5000;
@@ -224,9 +226,67 @@ public class Places implements ForwardingProfile.FeaturePostProcessor {
           maxZoom = 15.0f;
           kindRank = 3;
           if (population == 0) {
+            minZoom = 11.0f;
             population = 2000;
           }
           break;
+        case "locality":
+          kind = "locality";
+          // This minZoom can be changed to smaller value in the NE data join step below
+          minZoom = 12.0f;
+          maxZoom = 15.0f;
+          kindRank = 3;
+          if (population == 0) {
+            minZoom = 13.0f;
+            population = 1000;
+          }
+          break;
+        case "hamlet":
+          kind = "locality";
+          // This minZoom can be changed to smaller value in the NE data join step below
+          minZoom = 12.0f;
+          maxZoom = 15.0f;
+          kindRank = 3;
+          if (population == 0) {
+            minZoom = 13.0f;
+            population = 200;
+          }
+          break;
+        case "isolated_dwelling":
+          kind = "locality";
+          // This minZoom can be changed to smaller value in the NE data join step below
+          minZoom = 13.0f;
+          maxZoom = 15.0f;
+          kindRank = 3;
+          if (population == 0) {
+            minZoom = 14.0f;
+            population = 100;
+          }
+          break;
+        case "farm":
+          kind = "locality";
+          // This minZoom can be changed to smaller value in the NE data join step below
+          minZoom = 13.0f;
+          maxZoom = 15.0f;
+          kindRank = 3;
+          if (population == 0) {
+            minZoom = 14.0f;
+            population = 50;
+          }
+          break;
+        // NOTE (nvkelso 20240617): areas outside of main population center with different postal city in Eastern Europe
+        case "allotments":
+          kind = "locality";
+          // This minZoom can be changed to smaller value in the NE data join step below
+          minZoom = 13.0f;
+          maxZoom = 15.0f;
+          kindRank = 3;
+          if (population == 0) {
+            minZoom = 14.0f;
+            population = 1000;
+          }
+          break;
+        // NOTE (nvkelso 20240617): suburb can mean locality in some countries and should be localized
         case "suburb":
           kind = "neighbourhood";
           minZoom = 11.0f;

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
@@ -161,7 +161,7 @@ public class Places implements ForwardingProfile.FeaturePostProcessor {
       int themeMinZoom = 7;
       double minZoom = 12.0;
       double maxZoom = 15.0;
-      long population = 0;
+      int population = 0;
       if (sf.hasTag("population")) {
         Integer parsed = parseIntOrNull(sf.getString("population"));
         if (parsed != null) {

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
@@ -233,22 +233,22 @@ public class Places implements ForwardingProfile.FeaturePostProcessor {
         case "locality":
           kind = "locality";
           // This minZoom can be changed to smaller value in the NE data join step below
-          minZoom = 12.0f;
+          minZoom = 11.0f;
           maxZoom = 15.0f;
           kindRank = 3;
           if (population == 0) {
-            minZoom = 13.0f;
+            minZoom = 12.0f;
             population = 1000;
           }
           break;
         case "hamlet":
           kind = "locality";
           // This minZoom can be changed to smaller value in the NE data join step below
-          minZoom = 12.0f;
+          minZoom = 11.0f;
           maxZoom = 15.0f;
           kindRank = 3;
           if (population == 0) {
-            minZoom = 13.0f;
+            minZoom = 12.0f;
             population = 200;
           }
           break;

--- a/tiles/src/test/java/com/protomaps/basemap/layers/PlacesTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/PlacesTest.java
@@ -90,10 +90,100 @@ class PlacesTest extends LayerTest {
   @Test
   void testMinMaxLabelPopulatedPlaceNoMatch() {
     assertFeatures(12,
-      List.of(Map.of("_minzoom", 7, "pmap:kind", "locality")),
+      List.of(Map.of("_minzoom", 8, "pmap:kind", "locality")),
       process(SimpleFeature.create(
         newPoint(1, 1),
         new HashMap<>(Map.of("place", "city", "wikidata", "Q999", "name", "XX")),
+        "osm",
+        null,
+        0
+      )));
+  }
+
+  @Test
+  void testLocalityPopulationOsm() {
+    assertFeatures(13,
+      List.of(Map.of("pmap:kind", "locality",
+        "pmap:kind_detail", "locality",
+        "population", 1111)),
+      process(SimpleFeature.create(
+        newPoint(1, 1),
+        new HashMap<>(Map.of("place", "locality", "name", "Localityville", "population", "1111")),
+        "osm",
+        null,
+        0
+      )));
+  }
+
+  @Test
+  void testLocalityNoPopulationOsm() {
+    assertFeatures(14,
+      List.of(Map.of("pmap:kind", "locality",
+        "pmap:kind_detail", "locality",
+        "population", 1000)),
+      process(SimpleFeature.create(
+        newPoint(1, 1),
+        new HashMap<>(Map.of("place", "locality", "name", "Localityville")),
+        "osm",
+        null,
+        0
+      )));
+  }
+
+  @Test
+  void testHamletOsm() {
+    assertFeatures(14,
+      List.of(Map.of("pmap:kind", "locality",
+        "pmap:kind_detail", "hamlet",
+        "population", 200)),
+      process(SimpleFeature.create(
+        newPoint(1, 1),
+        new HashMap<>(Map.of("place", "hamlet", "name", "Hamletville")),
+        "osm",
+        null,
+        0
+      )));
+  }
+
+  @Test
+  void testIsolatedDwellingOsm() {
+    assertFeatures(14,
+      List.of(Map.of("pmap:kind", "locality",
+        "pmap:kind_detail", "isolated_dwelling",
+        "population", 100)),
+      process(SimpleFeature.create(
+        newPoint(1, 1),
+        new HashMap<>(Map.of("place", "isolated_dwelling", "name", "Isolatedville")),
+        "osm",
+        null,
+        0
+      )));
+  }
+
+  @Test
+  void testFarmOsm() {
+    assertFeatures(14,
+      List.of(Map.of("pmap:kind", "locality",
+        "pmap:kind_detail", "farm",
+        "population", 50)),
+      process(SimpleFeature.create(
+        newPoint(1, 1),
+        new HashMap<>(Map.of("place", "farm", "name", "Farmville")),
+        "osm",
+        null,
+        0
+      )));
+  }
+
+  @Test
+  void testAllotmentsOsm() {
+    assertFeatures(14,
+      List.of(Map.of("pmap:kind", "locality",
+        "pmap:kind_detail", "allotments",
+        "population", 1000)),
+      process(SimpleFeature.create(
+        newPoint(1, 1),
+        new HashMap<>(Map.of("place", "allotments", "name", "Allotmentville")),
         "osm",
         null,
         0


### PR DESCRIPTION
Fixes #258.

Adds additional `locality` kind features to the **places** layer, namely with `pmap:kind_detail` in `locality`, `hamlet`, `isolated_dwelling`, `farm`, and `allotments`.

All of those except allotment were present in Tilezen but not yet included in Protomaps.