### PR TITLE
add Dockerfile for building tiles [#184]

### DIFF
--- a/tiles/Dockerfile
+++ b/tiles/Dockerfile
@@ -1,0 +1,6 @@
+FROM maven:3-eclipse-temurin-22-alpine
+WORKDIR /tiles
+COPY src src
+COPY pom.xml pom.xml
+RUN mvn clean package
+ENTRYPOINT ["java","-jar","/tiles/target/protomaps-basemap-HEAD-with-deps.jar"]

--- a/tiles/README.md
+++ b/tiles/README.md
@@ -7,3 +7,4 @@ docker build -t protomaps/basemaps .
 ```
 docker run -v ./data:/tiles/data --rm -it protomaps/basemaps --output=data/monaco.pmtiles --area=monaco
 ```
+

--- a/tiles/README.md
+++ b/tiles/README.md
@@ -1,0 +1,9 @@
+## Docker
+
+```
+docker build -t protomaps/basemaps .
+```
+
+```
+docker run -v ./data:/tiles/data --rm -it protomaps/basemaps --output=data/monaco.pmtiles --area=monaco
+```


### PR DESCRIPTION
This sends the minimal build context to the container
add readme for mounting local volume to reuse downloads as well as write tiles to host. 