### PR TITLE
Places: don't use Natural Earth at low zooms [#256, #282]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Tiles v4.0.0-alpha.3
+------
+- Replace Natural Earth places at low zooms with OSM [#289]
+
 Tiles v4.0.0-alpha.2
 ------
 - Segment name by script via @wipfli [#273]

--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -100,7 +100,7 @@ public class Basemap extends ForwardingProfile {
 
   @Override
   public String version() {
-    return "4.0.0-alpha.2";
+    return "4.0.0-alpha.3";
   }
 
   @Override

--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -63,7 +63,6 @@ public class Basemap extends ForwardingProfile {
     var place = new Places(naturalEarthDb);
     registerHandler(place);
     registerSourceHandler("osm", place::processOsm);
-    registerSourceHandler("ne", place::processNe);
 
     var poi = new Pois(qrankDb);
     registerHandler(poi);


### PR DESCRIPTION
This makes the `places` data rely purely on OSM for geometries, removing the buggy duplication of places and making name labels consistent at all zoom levels. @wipfli @nvkelso 

Since we allowlist the OSM name tags this keeps the tile size reasonable at low zooms 0-7.