### PR TITLE
Fix highways

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -144,6 +144,8 @@ public class Roads implements ForwardingProfile.FeaturePostProcessor {
         // Core OSM tags for different kinds of places
         .setAttrWithMinzoom("layer", Parse.parseIntOrNull(sf.getString("layer")), 12)
         .setAttrWithMinzoom("oneway", sf.getString("oneway"), 14)
+        // `highway` is a temporary attribute that gets removed in the post-process step
+        .setAttr("highway", highway)
         .setMinPixelSize(0)
         .setPixelTolerance(0)
         .setZoomRange(minZoom, maxZoom);


### PR DESCRIPTION
Due to https://github.com/protomaps/basemaps/pull/285 we currently do not have highways in the tiles below z12.

This pull requests fixes that, but we might want to add some sort of test to avoid this in the future.
