### PR TITLE
Pre-collide places layer point features and reduce density / overlaps

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
@@ -36,13 +36,15 @@ public class Places implements ForwardingProfile.FeaturePostProcessor {
       // (nvkelso 20230803) floats with significant single decimal precision
       //                    but results in "Too many possible values"
       // Order ASCENDING (smaller manually curated Natural Earth min_zoom win over larger values, across kinds)
-      .orderByInt((int) minZoom, 0, 15)
+      // minZoom is a float with 1 significant digit for manually curated places
+      .orderByInt((int)(minZoom * 10), 0, 150)
       // Order ASCENDING (smaller values win, countries then locality then neighbourhood, breaks ties for same minZoom)
-      .thenByInt(kindRank, 0, 6)
+      .thenByInt(kindRank, 0, 12)
       // Order DESCENDING (larger values win, San Francisco rank 11 wins over Oakland rank 10)
-      .thenByInt(populationRank, 15, 0)
+      // Disabled to allow population log to have larger range
+      //.thenByInt(populationRank, 15, 0)
       // Order DESCENDING (larger values win, Millbrea 40k wins over San Bruno 20k, both rank 7)
-      .thenByLog(population, 1000000000, 1, 100)
+      .thenByLog(population, 40000000, 1, 100)
       // Order ASCENDING (shorter strings are better than longer strings for map display and adds predictability)
       .thenByInt(name == null ? 0 : name.length(), 0, 31)
       .get();
@@ -55,15 +57,30 @@ public class Places implements ForwardingProfile.FeaturePostProcessor {
 
   private static final ZoomFunction<Number> LOCALITY_GRID_SIZE_ZOOM_FUNCTION =
     ZoomFunction.fromMaxZoomThresholds(Map.of(
-      6, 32,
-      7, 64
+      3, 24,
+      4, 24,
+      5, 24,
+      7, 24,
+      8, 32,
+      9, 32,
+      10, 32,
+      11, 24,
+      14, 24,
+      15, 16
     ), 0);
 
   private static final ZoomFunction<Number> LOCALITY_GRID_LIMIT_ZOOM_FUNCTION =
     ZoomFunction.fromMaxZoomThresholds(Map.of(
-      6, 8,
-      7, 6,
-      9, 4
+      3, 1,
+      4, 1,
+      5, 1,
+      6, 1,
+      8, 1,
+      9, 1,
+      10, 1,
+      11, 1,
+      14, 2,
+      15, 3
     ), 0);
 
   public void processOsm(SourceFeature sf, FeatureCollector features) {
@@ -148,7 +165,7 @@ public class Places implements ForwardingProfile.FeaturePostProcessor {
           // This minZoom can be changed to smaller value in the NE data join step below
           minZoom = 11.0f;
           maxZoom = 15.0f;
-          kindRank = 3;
+          kindRank = 4;
           if (population == 0) {
             minZoom = 12.0f;
             population = 1000;
@@ -159,7 +176,7 @@ public class Places implements ForwardingProfile.FeaturePostProcessor {
           // This minZoom can be changed to smaller value in the NE data join step below
           minZoom = 11.0f;
           maxZoom = 15.0f;
-          kindRank = 3;
+          kindRank = 5;
           if (population == 0) {
             minZoom = 12.0f;
             population = 200;
@@ -170,7 +187,7 @@ public class Places implements ForwardingProfile.FeaturePostProcessor {
           // This minZoom can be changed to smaller value in the NE data join step below
           minZoom = 13.0f;
           maxZoom = 15.0f;
-          kindRank = 3;
+          kindRank = 6;
           if (population == 0) {
             minZoom = 14.0f;
             population = 100;
@@ -181,7 +198,7 @@ public class Places implements ForwardingProfile.FeaturePostProcessor {
           // This minZoom can be changed to smaller value in the NE data join step below
           minZoom = 13.0f;
           maxZoom = 15.0f;
-          kindRank = 3;
+          kindRank = 7;
           if (population == 0) {
             minZoom = 14.0f;
             population = 50;
@@ -193,7 +210,7 @@ public class Places implements ForwardingProfile.FeaturePostProcessor {
           // This minZoom can be changed to smaller value in the NE data join step below
           minZoom = 13.0f;
           maxZoom = 15.0f;
-          kindRank = 3;
+          kindRank = 8;
           if (population == 0) {
             minZoom = 14.0f;
             population = 1000;
@@ -204,19 +221,19 @@ public class Places implements ForwardingProfile.FeaturePostProcessor {
           kind = "neighbourhood";
           minZoom = 11.0f;
           maxZoom = 15.0f;
-          kindRank = 4;
+          kindRank = 9;
           break;
         case "quarter":
           kind = "macrohood";
           minZoom = 10.0f;
           maxZoom = 15.0f;
-          kindRank = 5;
+          kindRank = 10;
           break;
         case "neighbourhood":
           kind = "neighbourhood";
           minZoom = 12.0f;
           maxZoom = 15.0f;
-          kindRank = 6;
+          kindRank = 11;
           break;
       }
 
@@ -287,12 +304,14 @@ public class Places implements ForwardingProfile.FeaturePostProcessor {
       //feat.setSortKey(minZoom * 1000 + 400 - populationRank * 200 + placeNumber.incrementAndGet());
       feat.setSortKey(getSortKey(minZoom, kindRank, populationRank, population, sf.getString("name")));
 
+      // This is only necessary when prepping for raster renderers
+      feat.setBufferPixels(16);
+
       // We set the sort keys so the label grid can be sorted predictably (bonus: tile features also sorted)
       // NOTE: The buffer needs to be consistent with the innteral grid pixel sizes
       //feat.setPointLabelGridSizeAndLimit(13, 64, 4); // each cell in the 4x4 grid can have 4 items
       feat.setPointLabelGridPixelSize(LOCALITY_GRID_SIZE_ZOOM_FUNCTION)
-        .setPointLabelGridLimit(LOCALITY_GRID_LIMIT_ZOOM_FUNCTION)
-        .setBufferPixels(64);
+        .setPointLabelGridLimit(LOCALITY_GRID_LIMIT_ZOOM_FUNCTION);
 
       // and also whenever you set a label grid size limit, make sure you increase the buffer size so no
       // label grid squares will be the consistent between adjacent tiles

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
@@ -37,7 +37,7 @@ public class Places implements ForwardingProfile.FeaturePostProcessor {
       //                    but results in "Too many possible values"
       // Order ASCENDING (smaller manually curated Natural Earth min_zoom win over larger values, across kinds)
       // minZoom is a float with 1 significant digit for manually curated places
-      .orderByInt((int)(minZoom * 10), 0, 150)
+      .orderByInt((int) (minZoom * 10), 0, 150)
       // Order ASCENDING (smaller values win, countries then locality then neighbourhood, breaks ties for same minZoom)
       .thenByInt(kindRank, 0, 12)
       // Order DESCENDING (larger values win, San Francisco rank 11 wins over Oakland rank 10)


### PR DESCRIPTION
Fixes #287 and fixes #116 and related to label flickering in https://github.com/protomaps/basemaps/issues/286 and https://github.com/protomaps/basemaps/issues/256.

Adjusts the collision grid size and sort functions.

Testing in on the `california` make target, we see dramatic reduction in features from zooms 5 to 13, with the most reduction in zooms 8, 9, and 10:

```
                 z0    z1    z2    z3    z4    z5    z6    z7    z8    z9   z10   z11   z12   z13   z14   z15   all
  places after    0   858  2.6k  2.6k  3.4k  6.6k  5.5k  7.6k  7.3k  7.4k  5.2k  5.3k  5.4k    3k    2k  1.6k  7.6k
  places before   0  1.8k  2.6k  2.9k  4.3k  8.9k  6.5k   10k   16k   10k  7.3k  5.9k  6.9k  4.1k  2.2k  1.7k   16k
  ```
  
The archive size and feature count remained constant.