### PR TITLE
Add 2nd language option

### DIFF
--- a/app/src/MapViewComponent.tsx
+++ b/app/src/MapViewComponent.tsx
@@ -70,6 +70,7 @@ export const isValidPMTiles = (tiles?: string): boolean => {
 function getMaplibreStyle(
   theme: string,
   lang: string,
+  langSecondary: string,
   localSprites: boolean,
   tiles?: string,
   npmLayers?: LayerSpecification[],
@@ -123,16 +124,23 @@ function getMaplibreStyle(
   if (npmLayers && npmLayers.length > 0) {
     style.layers = style.layers.concat(npmLayers);
   } else {
-    style.layers = style.layers.concat(layers("protomaps", theme, lang));
+    style.layers = style.layers.concat(
+      layers("protomaps", theme, lang, langSecondary),
+    );
   }
   return style;
 }
 
-function StyleJsonPane(props: { theme: string; lang: string }) {
+function StyleJsonPane(props: {
+  theme: string;
+  lang: string;
+  langSecondary: string;
+}) {
   const stringified = JSON.stringify(
     getMaplibreStyle(
       props.theme,
       props.lang,
+      props.langSecondary,
       false,
       "https://example.com/tiles.json",
     ),
@@ -158,6 +166,7 @@ function StyleJsonPane(props: { theme: string; lang: string }) {
 function MapLibreView(props: {
   theme: string;
   lang: string;
+  langSecondary: string;
   localSprites: boolean;
   showBoxes: boolean;
   tiles?: string;
@@ -182,7 +191,7 @@ function MapLibreView(props: {
     const map = new maplibregl.Map({
       hash: "map",
       container: "map",
-      style: getMaplibreStyle("", "en", false),
+      style: getMaplibreStyle("", "en", undefined as any, false),
     });
 
     map.addControl(new maplibregl.NavigationControl());
@@ -268,6 +277,7 @@ function MapLibreView(props: {
           getMaplibreStyle(
             props.theme,
             props.lang,
+            props.langSecondary,
             props.localSprites,
             props.tiles,
             props.npmLayers,
@@ -282,6 +292,7 @@ function MapLibreView(props: {
     props.tiles,
     props.theme,
     props.lang,
+    props.langSecondary,
     props.localSprites,
     props.npmLayers,
     props.droppedArchive,
@@ -295,6 +306,9 @@ export default function MapViewComponent() {
   const hash = parseHash(location.hash);
   const [theme, setTheme] = useState<string>(hash.theme || "light");
   const [lang, setLang] = useState<string>(hash.lang || "en");
+  const [langSecondary, setLangSecondary] = useState<string>(
+    hash.langSecondary || (undefined as any),
+  );
   const [tiles, setTiles] = useState<string | undefined>(hash.tiles);
   const [localSprites, setLocalSprites] = useState<boolean>(
     hash.local_sprites === "true",
@@ -314,6 +328,7 @@ export default function MapViewComponent() {
     const record = {
       theme: theme,
       lang: lang,
+      langSecondary: langSecondary,
       tiles: tiles,
       local_sprites: localSprites ? "true" : undefined,
       show_boxes: showBoxes ? "true" : undefined,
@@ -327,8 +342,6 @@ export default function MapViewComponent() {
   }, []);
 
   const { getRootProps } = useDropzone({ onDrop });
-
-  // TODO: language tag selector
 
   useEffect(() => {
     if (!tiles) {
@@ -421,6 +434,25 @@ export default function MapViewComponent() {
             </option>
           ))}
         </select>
+        <select
+          onChange={(e) =>
+            setLangSecondary(
+              e.target.value === "2nd language..."
+                ? (undefined as any)
+                : e.target.value,
+            )
+          }
+          value={langSecondary}
+        >
+          <option key="undefined" value={undefined}>
+            2nd language...
+          </option>
+          {language_script_pairs.map((pair) => (
+            <option key={pair.lang} value={pair.lang}>
+              {pair.full_name}
+            </option>
+          ))}
+        </select>
         <input
           id="localSprites"
           type="checkbox"
@@ -473,10 +505,17 @@ export default function MapViewComponent() {
           showBoxes={showBoxes}
           theme={theme}
           lang={lang}
+          langSecondary={langSecondary}
           npmLayers={npmLayers}
           droppedArchive={droppedArchive}
         />
-        {showStyleJson && <StyleJsonPane theme={theme} lang={lang} />}
+        {showStyleJson && (
+          <StyleJsonPane
+            theme={theme}
+            lang={lang}
+            langSecondary={langSecondary}
+          />
+        )}
       </div>
     </div>
   );

--- a/styles/src/base_layers.ts
+++ b/styles/src/base_layers.ts
@@ -3,7 +3,11 @@ import {
   ExpressionSpecification,
   LayerSpecification,
 } from "@maplibre/maplibre-gl-style-spec";
-import { get_country_name, get_multiline_name } from "./language";
+import {
+  get_country_name,
+  get_multiline_name,
+  get_dual_name,
+} from "./language";
 import { Theme } from "./themes";
 
 export function nolabels_layers(
@@ -1554,8 +1558,13 @@ export function labels_layers(
   source: string,
   t: Theme,
   lang: string,
-  script?: string,
+  langSecondary?: string,
 ): LayerSpecification[] {
+  const textField = (
+    langSecondary === undefined
+      ? get_multiline_name(lang)
+      : get_dual_name(lang, langSecondary)
+  ) as DataDrivenPropertyValueSpecification<string>;
   return [
     {
       id: "water_waterway_label",
@@ -1567,10 +1576,7 @@ export function labels_layers(
       layout: {
         "symbol-placement": "line",
         "text-font": ["Noto Sans Regular"],
-        "text-field": get_multiline_name(
-          lang,
-          script,
-        ) as DataDrivenPropertyValueSpecification<string>,
+        "text-field": textField,
         "text-size": 12,
         "text-letter-spacing": 0.3,
       },
@@ -1586,10 +1592,7 @@ export function labels_layers(
       filter: ["any", ["==", "kind", "peak"]],
       layout: {
         "text-font": ["Noto Sans Italic"],
-        "text-field": get_multiline_name(
-          lang,
-          script,
-        ) as DataDrivenPropertyValueSpecification<string>,
+        "text-field": textField,
         "text-size": ["interpolate", ["linear"], ["zoom"], 10, 8, 16, 12],
         "text-letter-spacing": 0.1,
         "text-max-width": 9,
@@ -1610,10 +1613,7 @@ export function labels_layers(
         "symbol-sort-key": ["get", "min_zoom"],
         "symbol-placement": "line",
         "text-font": ["Noto Sans Regular"],
-        "text-field": get_multiline_name(
-          lang,
-          script,
-        ) as DataDrivenPropertyValueSpecification<string>,
+        "text-field": textField,
         "text-size": 12,
       },
       paint: {
@@ -1643,10 +1643,7 @@ export function labels_layers(
       ],
       layout: {
         "text-font": ["Noto Sans Medium"],
-        "text-field": get_multiline_name(
-          lang,
-          script,
-        ) as DataDrivenPropertyValueSpecification<string>,
+        "text-field": textField,
         "text-size": ["interpolate", ["linear"], ["zoom"], 3, 10, 10, 12],
         "text-letter-spacing": 0.1,
         "text-max-width": 9,
@@ -1664,10 +1661,7 @@ export function labels_layers(
       filter: ["any", ["in", "kind", "lake", "water"]],
       layout: {
         "text-font": ["Noto Sans Medium"],
-        "text-field": get_multiline_name(
-          lang,
-          script,
-        ) as DataDrivenPropertyValueSpecification<string>,
+        "text-field": textField,
         "text-size": ["interpolate", ["linear"], ["zoom"], 3, 0, 6, 12, 10, 12],
         "text-letter-spacing": 0.1,
         "text-max-width": 9,
@@ -1687,10 +1681,7 @@ export function labels_layers(
         "symbol-sort-key": ["get", "min_zoom"],
         "symbol-placement": "line",
         "text-font": ["Noto Sans Regular"],
-        "text-field": get_multiline_name(
-          lang,
-          script,
-        ) as DataDrivenPropertyValueSpecification<string>,
+        "text-field": textField,
         "text-size": 12,
       },
       paint: {
@@ -1707,10 +1698,7 @@ export function labels_layers(
       filter: ["==", "kind", "neighbourhood"],
       layout: {
         "symbol-sort-key": ["get", "min_zoom"],
-        "text-field": get_multiline_name(
-          lang,
-          script,
-        ) as DataDrivenPropertyValueSpecification<string>,
+        "text-field": textField,
         "text-font": ["Noto Sans Regular"],
         "text-max-width": 7,
         "text-letter-spacing": 0.1,
@@ -1755,10 +1743,7 @@ export function labels_layers(
       layout: {
         "icon-image": ["step", ["zoom"], "townspot", 8, ""],
         "icon-size": 0.7,
-        "text-field": get_multiline_name(
-          lang,
-          script,
-        ) as DataDrivenPropertyValueSpecification<string>,
+        "text-field": textField,
         "text-font": [
           "case",
           ["<=", ["get", "min_zoom"], 5],
@@ -1872,7 +1857,7 @@ export function labels_layers(
           ["zoom"],
           ["get", "name:short"],
           6,
-          get_multiline_name(lang, script) as ExpressionSpecification,
+          textField as ExpressionSpecification,
         ],
         "text-font": ["Noto Sans Regular"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 3, 11, 7, 16],
@@ -1894,10 +1879,9 @@ export function labels_layers(
       filter: ["==", "kind", "country"],
       layout: {
         "symbol-sort-key": ["get", "min_zoom"],
-        "text-field": get_country_name(
-          lang,
-          script,
-        ) as DataDrivenPropertyValueSpecification<string>,
+        "text-field": (langSecondary === undefined
+          ? get_country_name(lang)
+          : textField) as DataDrivenPropertyValueSpecification<string>,
         "text-font": ["Noto Sans Medium"],
         "text-size": [
           "interpolate",

--- a/styles/src/index.ts
+++ b/styles/src/index.ts
@@ -6,11 +6,11 @@ export default function (
   source: string,
   key: string,
   lang: string,
-  script?: string,
+  langSecondary?: string,
 ): LayerSpecification[] {
   const theme = themes[key];
   return nolabels_layers(source, theme).concat(
-    labels_layers(source, theme, lang, script),
+    labels_layers(source, theme, lang, langSecondary),
   );
 }
 
@@ -23,20 +23,20 @@ export function labels(
   source: string,
   key: string,
   lang: string,
-  script?: string,
+  langSecondary?: string,
 ): LayerSpecification[] {
   const theme = themes[key];
-  return labels_layers(source, theme, lang, script);
+  return labels_layers(source, theme, lang, langSecondary);
 }
 
 export function layersWithCustomTheme(
   source: string,
   theme: Theme,
   lang: string,
-  script?: string,
+  langSecondary?: string,
 ): LayerSpecification[] {
   return nolabels_layers(source, theme).concat(
-    labels_layers(source, theme, lang, script),
+    labels_layers(source, theme, lang, langSecondary),
   );
 }
 
@@ -45,11 +45,11 @@ export function layersWithPartialCustomTheme(
   key: string,
   partialTheme: Partial<Theme>,
   lang: string,
-  script?: string,
+  langSecondary?: string,
 ): LayerSpecification[] {
   const mergedTheme = { ...themes[key], ...partialTheme };
   return nolabels_layers(source, mergedTheme).concat(
-    labels_layers(source, mergedTheme, lang, script),
+    labels_layers(source, mergedTheme, lang, langSecondary),
   );
 }
 
@@ -64,7 +64,7 @@ export function labelsWithCustomTheme(
   source: string,
   theme: Theme,
   lang: string,
-  script?: string,
+  langSecondary?: string,
 ): LayerSpecification[] {
-  return labels_layers(source, theme, lang, script);
+  return labels_layers(source, theme, lang, langSecondary);
 }


### PR DESCRIPTION
Adds an option to display labels in a second target language.

![image](https://github.com/user-attachments/assets/b0f6ee75-1958-4504-b2e3-76fbc3a8138f)

The code for regular language localization in `get_multiline_name()` takes the target script and the local script(s) into account. Since there is already a high level of complexity in this function I decided to create a new function `get_dual_name(langPrimary, langSecondary)`. It roughly behaves like this:

```
if both target languages are present
  if both languages are the same
    only show one language
  else
     show both languages
else if no target language is present
  use default "name"
else
  show the language which is present
``` 

When refactoring the code to support a second language, I noticed that the optional `script` argument in `get_multiline_name()` does not make a lot of sense. I currently don't see a situation where the user would want to specify a script for a language other than the defaults that we have. I therefore removed the script parameter. From semver's point of view this is a breaking change.