### PR TITLE
roads kind=ferry: filter by route=ferry instead of ferry=*. fixes [#312]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Tiles v4.0.1
+------
+- fix `roads` `kind=ferry`, remove ferry `kind_detail` [#312]
+
 Styles v4.0.0 + Tiles v4.0.0
 ------
 - Remove `medium_road`

--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -86,7 +86,7 @@ public class Basemap extends ForwardingProfile {
 
   @Override
   public String version() {
-    return "4.0.0";
+    return "4.0.1";
   }
 
   @Override

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -225,9 +225,8 @@ public class Roads implements ForwardingProfile.LayerPostProcesser {
             minZoom = 14;
           }
         }
-      } else if (sf.hasTag("ferry")) {
+      } else if (sf.hasTag("route", "ferry")) {
         kind = "ferry";
-        kindDetail = sf.getString("ferry");
       } else if (sf.hasTag("man_made", "pier")) {
         kind = "path";
         kindDetail = "pier";


### PR DESCRIPTION
@nvkelso this is to match https://tilezen.readthedocs.io/en/latest/layers/#road-transportation-kind_detail-values-and-zoom-ranges

> Ferries from both Natural Earth and OpenStreetMap are shown starting at zoom 5 with kind values of ferry.

as well as what's in http://tangrams.github.io/bubble-wrap/#15.595833333333331/37.7923/-122.3811