### PR TITLE
fix typo `min_height` attributes in buildings layer

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Buildings.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Buildings.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 public class Buildings implements ForwardingProfile.LayerPostProcesser {
 
   static final String HEIGHT_KEY = "height";
-  static final String MIN_HEIGHT_KEY = "height";
+  static final String MIN_HEIGHT_KEY = "min_height";
 
   @Override
   public String name() {


### PR DESCRIPTION
close #323 