### PR TITLE
Change `kind` attribute of OSMData sourced-water to `ocean`

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -25,7 +25,7 @@ public class Water implements ForwardingProfile.LayerPostProcesser {
 
   public void processPreparedOsm(SourceFeature ignoredSf, FeatureCollector features) {
     features.polygon(this.name())
-      .setAttr("kind", "water")
+      .setAttr("kind", "ocean")
       .setAttr("sort_rank", 200)
       .setZoomRange(6, 15).setBufferPixels(8);
   }


### PR DESCRIPTION
Closes #329 

Let me preface by saying I don't know Java and I'm not very familiar with this codebase, so please excuse any amateur mistakes or oversights. I've marked this PR as a draft to ensure nobody mistakes me for someone who knows what they're doing.

As described in #329, the value of `kind` for oceanic features switches from `ocean` in z5 to `water` in z6. I think this inconsistency at different zoom levels is undesirable, and it precludes data users from being able to treat oceans differently from inland water. For example, in my own case, I'm wanting to use inland water data from the USGS rather than OSM for a US-focused map, while still using Natural Earth/OSMData for the oceans, but need a way to differentiate the two by attribute.

Since the water from the OSMData source only includes oceans (by design), it should be accurate to tag all water features from this source as `kind: ocean`, which is what this PR does.