### PR TITLE
Fix geometry-type filter on water to be MapLibre v5 compatible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Styles v4.3.1
+------
+* Fix `$type` in water filters to be MapLibre v5.0 compatible.
+
 Tiles v4.0.3
 ------
 - fix water `kind=ocean` via @dericke [#329]

--- a/styles/package-lock.json
+++ b/styles/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "protomaps-themes-base",
-  "version": "4.2.0",
+  "version": "4.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "protomaps-themes-base",
-      "version": "4.2.0",
+      "version": "4.3.1",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@biomejs/biome": "^1.5.3",

--- a/styles/package.json
+++ b/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protomaps-themes-base",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Protomaps basemap themes for MapLibre GL JS",
   "type": "module",
   "main": "dist/cjs/index.cjs",

--- a/styles/src/base_layers.ts
+++ b/styles/src/base_layers.ts
@@ -21,7 +21,7 @@ export function nolabels_layers(
     {
       id: "earth",
       type: "fill",
-      filter: ["==", ["geometry-type"], "Polygon"],
+      filter: ["==", "$type", "Polygon"],
       source: source,
       "source-layer": "earth",
       paint: {
@@ -253,7 +253,7 @@ export function nolabels_layers(
     {
       id: "water",
       type: "fill",
-      filter: ["==", ["geometry-type"], "Polygon"],
+      filter: ["==", "$type", "Polygon"],
       source: source,
       "source-layer": "water",
       paint: {


### PR DESCRIPTION
* Replace [geometry-type] with  to filter geometries correctly.