### PR TITLE
Fixes from accessibility audit.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Protomaps Basemaps</title>
     <link rel="preconnect" href="https://demo-bucket.protomaps.com"/>
   </head>

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,7 +8,7 @@
       "name": "protomaps-basemaps-app",
       "version": "0.0.0",
       "dependencies": {
-        "@maplibre/maplibre-gl-inspect": "^1.7.0",
+        "@maplibre/maplibre-gl-inspect": "^1.7.1",
         "maplibre-gl": "5.0.0",
         "pixelmatch": "^5.3.0",
         "pmtiles": "^4.1.0",
@@ -1021,9 +1021,9 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-inspect/-/maplibre-gl-inspect-1.7.0.tgz",
-      "integrity": "sha512-O2C78Dh9zRvVLrm0axgzB9do5spoOGqMnN34xmJVedQWco6tCq49oSyeMuGyBEX9fE9/zLwynnZrAfT5FRN1pQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-inspect/-/maplibre-gl-inspect-1.7.1.tgz",
+      "integrity": "sha512-e4f1LBZT58L4oUQ8qA16nbiq5Y1sgqIaruDcpWpi2/UE1yAl/0XASZq3x9vDOkM9XshyxBMDz1nNZfJoqIIoXw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lodash.isequal": "^4.5.0",

--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,7 @@
 		"format": "biome format --write src test --javascript-formatter-indent-style=space --json-formatter-indent-style=space"
 	},
 	"dependencies": {
-		"@maplibre/maplibre-gl-inspect": "^1.7.0",
+		"@maplibre/maplibre-gl-inspect": "^1.7.1",
 		"maplibre-gl": "5.0.0",
 		"pixelmatch": "^5.3.0",
 		"pmtiles": "^4.1.0",

--- a/app/src/Builds.tsx
+++ b/app/src/Builds.tsx
@@ -12,7 +12,7 @@ interface Build {
   version: string;
 }
 
-function toDate(dateStr: string): boolean {
+function toDate(dateStr: string): Date {
   const year = Number.parseInt(dateStr.substring(0, 4), 10);
   const month = Number.parseInt(dateStr.substring(4, 6), 10) - 1; // Subtract 1 because months are 0-indexed in JavaScript dates
   const day = Number.parseInt(dateStr.substring(6, 8), 10);
@@ -103,7 +103,7 @@ function BuildComponent(props: {
         </a>
       </td>
       <td class="hidden lg:table-cell">
-        {date >= "20231228" ? (
+        {dateStr >= "20231228" ? (
           <a class="underline" href={statsLink}>
             stats
           </a>

--- a/app/src/MapView.tsx
+++ b/app/src/MapView.tsx
@@ -188,6 +188,8 @@ function MapLibreView(props: {
   let protocolRef: Protocol | undefined;
   let hiddenRef: HTMLDivElement | undefined;
 
+  const [error, setError] = createSignal<string | undefined>();
+
   onMount(() => {
     if (getRTLTextPluginStatus() === "unavailable") {
       setRTLTextPlugin(
@@ -239,6 +241,14 @@ function MapLibreView(props: {
       closeButton: true,
       closeOnClick: false,
       maxWidth: "none",
+    });
+
+    map.on("error", (e) => {
+      setError(e.error.message);
+    });
+
+    map.on("idle", () => {
+      setError(undefined);
     });
 
     map.on("contextmenu", (e) => {
@@ -318,6 +328,11 @@ function MapLibreView(props: {
     <>
       <div class="hidden" ref={hiddenRef} />
       <div ref={mapContainer} class="h-100 w-full flex" />
+      <Show when={error()}>
+        <div class="absolute h-20 w-full flex justify-center items-center bg-white bg-opacity-50 font-mono text-red">
+          {error()}
+        </div>
+      </Show>
     </>
   );
 }
@@ -421,33 +436,54 @@ function MapView() {
       <div class="max-w-[1500px] mx-auto">
         <form onSubmit={loadTiles} class="flex">
           <input
-            class="border-2 border-gray p-1 flex-1 mr-2"
+            class="border-2 border-gray p-1 flex-1 mr-2 text-xs lg:text-base"
             type="text"
             name="tiles"
             value={tiles()}
             style={{ width: "50%" }}
+            autocomplete="off"
           />
           <button class="btn-primary" type="submit">
             load
           </button>
         </form>
-        <div class="my-2 space-x-2">
-          <select onChange={(e) => setTheme(e.target.value)} value={theme()}>
-            <option value="light">light</option>
-            <option value="dark">dark</option>
-            <option value="white">data viz (white)</option>
-            <option value="grayscale">data viz (grayscale)</option>
-            <option value="black">data viz (black)</option>
-          </select>
-          <select onChange={(e) => setLang(e.target.value)} value={lang()}>
-            <For each={language_script_pairs}>
-              {(pair) => (
-                <option value={pair.lang}>
-                  {pair.lang} ({pair.full_name})
-                </option>
-              )}
-            </For>
-          </select>
+        <div class="flex my-2 space-y-2 lg:space-y-0 space-x-2 flex-col lg:flex-row items-center">
+          <div class="flex items-center">
+            <label for="theme" class="text-xs mr-1">
+              theme
+            </label>
+            <select
+              id="theme"
+              onChange={(e) => setTheme(e.target.value)}
+              value={theme()}
+              autocomplete="on"
+            >
+              <option value="light">light</option>
+              <option value="dark">dark</option>
+              <option value="white">data viz (white)</option>
+              <option value="grayscale">data viz (grayscale)</option>
+              <option value="black">data viz (black)</option>
+            </select>
+          </div>
+          <div class="flex items-center">
+            <label for="lang" class="text-xs mr-1">
+              language
+            </label>
+            <select
+              id="lang"
+              onChange={(e) => setLang(e.target.value)}
+              value={lang()}
+              autocomplete="on"
+            >
+              <For each={language_script_pairs}>
+                {(pair) => (
+                  <option value={pair.lang}>
+                    {pair.lang} ({pair.full_name})
+                  </option>
+                )}
+              </For>
+            </select>
+          </div>
           <div class="hidden lg:inline">
             <input
               id="localSprites"
@@ -497,7 +533,7 @@ function MapView() {
             class="btn-primary hidden lg:inline"
             onClick={() => setShowStyleJson(!showStyleJson())}
           >
-            get style JSON
+            {showStyleJson() ? "Close style JSON" : "Get style JSON"}
           </button>
         </div>
       </div>

--- a/app/src/VisualTests.tsx
+++ b/app/src/VisualTests.tsx
@@ -383,7 +383,7 @@ function VisualTests() {
   return (
     <div class="flex flex-col h-screen w-full">
       <Nav page={2} />
-      <div class="w-[1500px] mx-auto">
+      <div class="w-[1500px] mx-auto p-2">
         <h1 class="my-8 text-4xl">Visual Tests</h1>
         <div class="inline-block w-[500px] font-mono text-xs">
           leftTiles={displayInfo().leftTiles}

--- a/app/tailwind.config.ts
+++ b/app/tailwind.config.ts
@@ -6,7 +6,8 @@ export default {
       purple: "#3131DC",
       white: "#FFFFFF",
       black: "#000000",
-      gray: "#E7E7F9"
+      gray: "#E7E7F9",
+      red: "#FF0000"
     },
 	},
 	plugins: [],


### PR DESCRIPTION
## a11y issues

> 1. The ‘Inspect button’ on the map, which serves as a toggle, doesn’t contain a clear value or indicator whether it is activated or not. This is needed for screen reader users to identify the current state of the toggle. This same issue occurs when opening or closing the ‘get style JSON’ button in the top navigation.

Added a label to maplibre-gl-inspect.

> 2. The two combo boxes above the map don’t have an accessible name, which means screen reader users will only hear ‘combo box German’ but can’t perceive the meaning of the combo box.

Added `label for=` HTML elements.

> 3. The radio buttons in the protomap builds page don’t have an accessible name. The screen reader will read ‘radio button checked 1 of 1’ but doesn’t say what this button is for.

Added `aria-label` indicating selected build dates.

> 4. When a wrong url is submitted in the input field on the top of the map, which leads to the map not being displayed anymore, there is no identification in text that an error has occurred. Providing information about input errors in text allows users who are blind or color deficient (color blind) to perceive the fact that an error occurred.

Added popover to display map loading errors such as 404.

> 5. The ‘user-scalable’ option is set to ‘no’, so users can’t resize the web page. This means that people who need to increase the size of interface elements to be able to interact with them, can’t fully use the website.

Removed this part of the HTML head tags.

> 6. For any form field that serves an identified input purpose, provide the appropriate autocomplete attribute.

Added `autocomplete` attributes.

> 7. When displaying the webpage at 320 pixels wide, a part of the text behind the radio buttons is no longer visible without having to scroll in two directions.

Hide some table columns on small breakpoints.

### Other findings

> 1. The buttons in the top right corner of the navigation bar are very close together; by increasing
the space between them, the buttons will be easier to use.

New navbar among all pages at top.


> 2. We are not sure whether this is a bug or that we just don’t understand this functionality, but
when pressing on a radio button in the ‘builds’ page, other radio buttons appear next to other
radio buttons and disappear when pressing (again) other radio buttons.

This is meant to mirror the Wikipedia "revisions" UI. Made the display of the radio buttons unconditional so they don't appear/disappear. 

