### PR TITLE
Link to builds docs on build retention; undo visual tests CSS change …

### DIFF
--- a/app/src/Builds.tsx
+++ b/app/src/Builds.tsx
@@ -187,7 +187,7 @@ function Builds() {
       <Nav page={1} />
       <div class="max-w-[1500px] mx-auto">
         <h1 class="my-8 text-4xl">Builds</h1>
-        <p>Only Monday builds (black) are kept indefinitely.</p>
+        <p>See the <a class="underline" href="https://docs.protomaps.com/basemaps/downloads" target="_blank">Documentation</a> for how to use.</p>
         <div class="space-x-2 my-2">
           <button class="btn-primary" type="button" onClick={openVisualTests}>
             Compare selected versions

--- a/app/src/VisualTests.tsx
+++ b/app/src/VisualTests.tsx
@@ -383,7 +383,7 @@ function VisualTests() {
   return (
     <div class="flex flex-col h-screen w-full">
       <Nav page={2} />
-      <div class="w-[1500px] mx-auto p-2">
+      <div class="w-[1500px] mx-auto">
         <h1 class="my-8 text-4xl">Visual Tests</h1>
         <div class="inline-block w-[500px] font-mono text-xs">
           leftTiles={displayInfo().leftTiles}


### PR DESCRIPTION
…because of overflow.