### PR TITLE
switch from build-metadata to npm-style.protomaps.dev for dynamically…

### DIFF
--- a/app/src/Builds.tsx
+++ b/app/src/Builds.tsx
@@ -195,14 +195,14 @@ function Builds() {
       type: "maplibre-gl",
       renderer: "maplibre-gl",
       index: 0,
-      url: `https://build-metadata.protomaps.dev/style@${latestStyle()}+theme@${theme}+tiles@${leftKey}.json`,
+      url: `https://npm-style.protomaps.dev/style.json?version=${latestStyle()}&theme=${theme}&tiles=${leftKey}`,
     };
     const right: MaperturePayload = {
       name: `${rightKey} ${latestStyle()} ${theme}`,
       type: "maplibre-gl",
       renderer: "maplibre-gl",
       index: 0,
-      url: `https://build-metadata.protomaps.dev/style@${latestStyle()}+theme@${theme}+tiles@${rightKey}.json`,
+      url: `https://npm-style.protomaps.dev/style.json?version=${latestStyle()}&theme=${theme}&tiles=${rightKey}`,
     };
     const payload = JSON.stringify([left, right]);
     open(

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -26,18 +26,8 @@ export function createHash(
 }
 
 export async function layersForVersion(version: string, theme?: string) {
-  if (version >= "4.0.0") {
-    const resp = await fetch(
-      `https://unpkg.com/protomaps-themes-base@${version}/dist/styles/${
-        theme || "light"
-      }/en.json`,
-    );
-    return (await resp.json()).layers;
-  }
   const resp = await fetch(
-    `https://unpkg.com/protomaps-themes-base@${version}/dist/layers/${
-      theme || "light"
-    }.json`,
+    `https://npm-style.protomaps.dev/layers.json?version=${version}&theme=${theme || "light"}&lang=en`
   );
   return await resp.json();
 }


### PR DESCRIPTION
… fetching NPM versions.

this will let us deprecate the pre-generated styles on NPM.