### PR TITLE
Bump planetiler to v0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Tiles v4.1.0
+------
+- bump planetiler to 0.8.4-SNAPSHOT, via @wipfli [#365]
+
 Tiles v4.0.4
 ------
 - fix antarctica landcover not extending to bottom with Natural Earth, via @wipfli [#337]

--- a/tiles/pom.xml
+++ b/tiles/pom.xml
@@ -9,7 +9,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <planetiler.version>0.8-SNAPSHOT</planetiler.version>
+    <planetiler.version>0.8.4-SNAPSHOT</planetiler.version>
     <junit.version>5.10.0</junit.version>
     <mainClass>com.protomaps.basemap.Basemap</mainClass>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -86,7 +86,7 @@ public class Basemap extends ForwardingProfile {
 
   @Override
   public String version() {
-    return "4.0.4";
+    return "4.1.0";
   }
 
   @Override


### PR DESCRIPTION
By bumping Planetiler to v0.8.4, we can make use of the new Loop Line Merger in the FeatureMerge.mergeLineStrings function. It breaks small loops which reduces the chances of getting 3+ way junctions are intersections and roundabouts. Previously, the JTS line merging would not be able to merge at such 3+ way junctions and because of that, lines would not get merged at roundabouts and then they would be short and fall out of the tiles in the min length pruning. This led so far to a lot of gaps on `highway=primary` roads in particular.

Here are some screenshots:

## Before

https://pmtiles.io/?url=https%3A%2F%2Fprotomaps.dev%2F%7Ewipfli%2F365%2Fv4-0.8-SNAPSHOT.pmtiles#map=7.06/46.901/8.791

![Screenshot_20250122_084018](https://github.com/user-attachments/assets/6be8c568-3e98-4514-a671-bcbe9069e23b)

## After

https://pmtiles.io/?url=https%3A%2F%2Fprotomaps.dev%2F%7Ewipfli%2F365%2Fv4-0.8.4-SNAPSHOT.pmtiles#map=7.06/46.901/8.791

![Screenshot_20250122_082611](https://github.com/user-attachments/assets/be866082-63b6-49ba-b5d5-110f19fb2e57)

