### PR TITLE
Add callouts on compatible NPM versions on builds page.

### DIFF
--- a/app/src/Builds.tsx
+++ b/app/src/Builds.tsx
@@ -2,6 +2,7 @@
 import { render } from "solid-js/web";
 import "./index.css";
 import Nav from "./Nav";
+import { VERSION_COMPATIBILITY } from "./utils";
 
 import { For, Show, createResource, createSignal } from "solid-js";
 
@@ -109,7 +110,10 @@ function BuildComponent(props: {
         />
       </td>
       <td title={build.uploaded}>{build.key}</td>
-      <td>{build.version}</td>
+      <td>
+        {build.version}{" "}
+        {build.version < "4" ? "(requires old style version)" : ""}
+      </td>
       <td class="hidden lg:table-cell">{formatBytes(build.size)}</td>
       <td class="hidden lg:table-cell">{Hashes(build)}</td>
       <td>
@@ -181,6 +185,18 @@ function Builds() {
 
   const theme = "light";
 
+  const latestMajorTileVersion = () => {
+    const b = builds();
+    if (b) return +b[0].version.split(".")[0];
+  };
+
+  const compatibleNpmVersions = () => {
+    const l = latestMajorTileVersion();
+    if (l) {
+      return VERSION_COMPATIBILITY[l].join(", ");
+    }
+  };
+
   const openVisualTests = () => {
     const left = `https://build.protomaps.com/${builds()[cmpA()].key}`;
     const right = `https://build.protomaps.com/${builds()[cmpB()].key}`;
@@ -226,6 +242,19 @@ function Builds() {
             Documentation
           </a>{" "}
           for how to use.
+        </p>
+        <p>
+          The latest tiles version ({latestMajorTileVersion()}) is compatible
+          with{" "}
+          <a
+            class="underline"
+            target="_blank"
+            rel="noreferrer"
+            href="https://www.npmjs.com/package/@protomaps/basemaps"
+          >
+            @protomaps/basemaps
+          </a>{" "}
+          versions {compatibleNpmVersions()}.
         </p>
         <div class="space-x-2 my-2">
           <button class="btn-primary" type="button" onClick={openVisualTests}>

--- a/app/src/MapView.tsx
+++ b/app/src/MapView.tsx
@@ -41,18 +41,12 @@ import {
   isValidPMTiles,
   layersForVersion,
   parseHash,
+  VERSION_COMPATIBILITY,
 } from "./utils";
 
 const STYLE_MAJOR_VERSION = 5;
 
 const DEFAULT_TILES = "https://demo-bucket.protomaps.com/v4.pmtiles";
-
-const VERSION_COMPATIBILITY: Record<number, number[]> = {
-  4: [4, 5],
-  3: [3],
-  2: [2],
-  1: [1],
-};
 
 const ATTRIBUTION =
   '<a href="https://github.com/protomaps/basemaps">Protomaps</a> © <a href="https://openstreetmap.org">OpenStreetMap</a>';

--- a/app/src/MapView.tsx
+++ b/app/src/MapView.tsx
@@ -37,11 +37,11 @@ import { type Flavor, layers, namedFlavor } from "../../styles/src/index.ts";
 import { language_script_pairs } from "../../styles/src/language.ts";
 import Nav from "./Nav";
 import {
+  VERSION_COMPATIBILITY,
   createHash,
   isValidPMTiles,
   layersForVersion,
   parseHash,
-  VERSION_COMPATIBILITY,
 } from "./utils";
 
 const STYLE_MAJOR_VERSION = 5;

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -1,3 +1,10 @@
+export const VERSION_COMPATIBILITY: Record<number, number[]> = {
+  4: [4, 5],
+  3: [3],
+  2: [2],
+  1: [1],
+};
+
 // Get the hash contents as a map.
 export function parseHash(hash: string): Record<string, string> {
   const retval: Record<string, string> = {};


### PR DESCRIPTION
Since we now have a different major version between the NPM package and the tileset. 