### PR TITLE
Update Buildings.java: remove "else" so that polygon-buildings with an address get address data too

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Buildings.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Buildings.java
@@ -97,7 +97,9 @@ public class Buildings implements ForwardingProfile.LayerPostProcesser {
       // Names should mostly just be for POIs
       // Sometimes building name and address are useful items, but only at zoom 17+
       //OsmNames.setOsmNames(feature, sf, 13);
-    } else if (sf.hasTag("addr:housenumber")) {
+    } 
+    
+    if (sf.hasTag("addr:housenumber")) {
       FeatureCollector.Feature feature = null;
       if (sf.isPoint()) {
         feature = features.point(this.name());


### PR DESCRIPTION
The current implementation is:

```
if( (sf.hasTag("building") && sf.canBePolygon()) || ... ){
  ... stuff ...
} else if (sf.hasTag("addr:housenumber")){
  ... actually add the housenumber ...
}
```

This means that a building (as polygon) will _never_ reach the else block where the address information is added. This means that the majority of buildings in Belgium (and many other countries) won't get address data included.

My fix is simply to remove this else. Note: I didn't test anything.