### PR TITLE
`--layer` cli config option

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -29,7 +29,8 @@ import java.util.Map;
 
 public class Basemap extends ForwardingProfile {
 
-  public Basemap(NaturalEarthDb naturalEarthDb, QrankDb qrankDb, CountryCoder countryCoder, Clip clip, String renderOnly) {
+  public Basemap(NaturalEarthDb naturalEarthDb, QrankDb qrankDb, CountryCoder countryCoder, Clip clip,
+    String renderOnly) {
 
     if (renderOnly.isEmpty() || renderOnly.equals("Boundaries")) {
       var admin = new Boundaries();
@@ -91,7 +92,7 @@ public class Basemap extends ForwardingProfile {
     if (renderOnly.isEmpty() || renderOnly.equals("Earth")) {
       var earth = new Earth();
       registerHandler(earth);
-  
+
       registerSourceHandler("osm", earth::processOsm);
       registerSourceHandler("osm_land", earth::processPreparedOsm);
       registerSourceHandler("ne", earth::processNe);
@@ -194,20 +195,22 @@ public class Basemap extends ForwardingProfile {
     }
 
     List<String> renderOnlyOptions = List.of(
-      "Boundaries", 
-      "Buildings", 
-      "Landuse", 
-      "Landcover", 
-      "Places", 
-      "Pois", 
-      "Roads", 
-      "Transit", 
-      "Water", 
+      "Boundaries",
+      "Buildings",
+      "Landuse",
+      "Landcover",
+      "Places",
+      "Pois",
+      "Roads",
+      "Transit",
+      "Water",
       "Earth"
     );
-    String renderOnly = args.getString("render_only", "Render only a single layer. Possible values are: " + String.join(", ", renderOnlyOptions), "");
+    String renderOnly = args.getString("render_only",
+      "Render only a single layer. Possible values are: " + String.join(", ", renderOnlyOptions), "");
     if (!(renderOnly.isEmpty() || renderOnlyOptions.contains(renderOnly))) {
-      System.err.println("Error: --render_only=\"" + renderOnly + "\" is not a valid option. Possible values are: " + String.join(", ", renderOnlyOptions));
+      System.err.println("Error: --render_only=\"" + renderOnly + "\" is not a valid option. Possible values are: " +
+        String.join(", ", renderOnlyOptions));
       System.exit(1);
     }
 

--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -32,56 +32,56 @@ public class Basemap extends ForwardingProfile {
   public Basemap(NaturalEarthDb naturalEarthDb, QrankDb qrankDb, CountryCoder countryCoder, Clip clip,
     String renderOnly) {
 
-    if (renderOnly.isEmpty() || renderOnly.equals("Boundaries")) {
+    if (renderOnly.isEmpty() || renderOnly.equals(Boundaries.LAYER_NAME)) {
       var admin = new Boundaries();
       registerHandler(admin);
       registerSourceHandler("osm", admin::processOsm);
       registerSourceHandler("ne", admin::processNe);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals("Buildings")) {
+    if (renderOnly.isEmpty() || renderOnly.equals(Buildings.LAYER_NAME)) {
       var buildings = new Buildings();
       registerHandler(buildings);
       registerSourceHandler("osm", buildings::processOsm);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals("Landuse")) {
+    if (renderOnly.isEmpty() || renderOnly.equals(Landuse.LAYER_NAME)) {
       var landuse = new Landuse();
       registerHandler(landuse);
       registerSourceHandler("osm", landuse::processOsm);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals("Landcover")) {
+    if (renderOnly.isEmpty() || renderOnly.equals(Landcover.LAYER_NAME)) {
       var landcover = new Landcover();
       registerHandler(landcover);
       registerSourceHandler("landcover", landcover::processLandcover);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals("Places")) {
+    if (renderOnly.isEmpty() || renderOnly.equals(Places.LAYER_NAME)) {
       var place = new Places(naturalEarthDb);
       registerHandler(place);
       registerSourceHandler("osm", place::processOsm);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals("Pois")) {
+    if (renderOnly.isEmpty() || renderOnly.equals(Pois.LAYER_NAME)) {
       var poi = new Pois(qrankDb);
       registerHandler(poi);
       registerSourceHandler("osm", poi::processOsm);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals("Roads")) {
+    if (renderOnly.isEmpty() || renderOnly.equals(Roads.LAYER_NAME)) {
       var roads = new Roads(countryCoder);
       registerHandler(roads);
       registerSourceHandler("osm", roads::processOsm);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals("Transit")) {
+    if (renderOnly.isEmpty() || renderOnly.equals(Transit.LAYER_NAME)) {
       var transit = new Transit();
       registerHandler(transit);
       registerSourceHandler("osm", transit::processOsm);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals("Water")) {
+    if (renderOnly.isEmpty() || renderOnly.equals(Water.LAYER_NAME)) {
       var water = new Water();
       registerHandler(water);
       registerSourceHandler("osm", water::processOsm);
@@ -89,7 +89,7 @@ public class Basemap extends ForwardingProfile {
       registerSourceHandler("ne", water::processNe);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals("Earth")) {
+    if (renderOnly.isEmpty() || renderOnly.equals(Earth.LAYER_NAME)) {
       var earth = new Earth();
       registerHandler(earth);
 
@@ -195,21 +195,22 @@ public class Basemap extends ForwardingProfile {
     }
 
     List<String> renderOnlyOptions = List.of(
-      "Boundaries",
-      "Buildings",
-      "Landuse",
-      "Landcover",
-      "Places",
-      "Pois",
-      "Roads",
-      "Transit",
-      "Water",
-      "Earth"
+      Boundaries.LAYER_NAME,
+      Buildings.LAYER_NAME,
+      Landuse.LAYER_NAME,
+      Landcover.LAYER_NAME,
+      Places.LAYER_NAME,
+      Pois.LAYER_NAME,
+      Roads.LAYER_NAME,
+      Transit.LAYER_NAME,
+      Water.LAYER_NAME,
+      Earth.LAYER_NAME
     );
+
     String renderOnly = args.getString("render_only",
       "Render only a single layer. Possible values are: " + String.join(", ", renderOnlyOptions), "");
     if (!(renderOnly.isEmpty() || renderOnlyOptions.contains(renderOnly))) {
-      System.err.println("Error: --render_only=\"" + renderOnly + "\" is not a valid option. Possible values are: " +
+      System.err.println("Error: --render_only=" + renderOnly + " is not a valid option. Possible values are: " +
         String.join(", ", renderOnlyOptions));
       System.exit(1);
     }

--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -30,58 +30,58 @@ import java.util.Map;
 public class Basemap extends ForwardingProfile {
 
   public Basemap(NaturalEarthDb naturalEarthDb, QrankDb qrankDb, CountryCoder countryCoder, Clip clip,
-    String renderOnly) {
+    String layer) {
 
-    if (renderOnly.isEmpty() || renderOnly.equals(Boundaries.LAYER_NAME)) {
+    if (layer.isEmpty() || layer.equals(Boundaries.LAYER_NAME)) {
       var admin = new Boundaries();
       registerHandler(admin);
       registerSourceHandler("osm", admin::processOsm);
       registerSourceHandler("ne", admin::processNe);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals(Buildings.LAYER_NAME)) {
+    if (layer.isEmpty() || layer.equals(Buildings.LAYER_NAME)) {
       var buildings = new Buildings();
       registerHandler(buildings);
       registerSourceHandler("osm", buildings::processOsm);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals(Landuse.LAYER_NAME)) {
+    if (layer.isEmpty() || layer.equals(Landuse.LAYER_NAME)) {
       var landuse = new Landuse();
       registerHandler(landuse);
       registerSourceHandler("osm", landuse::processOsm);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals(Landcover.LAYER_NAME)) {
+    if (layer.isEmpty() || layer.equals(Landcover.LAYER_NAME)) {
       var landcover = new Landcover();
       registerHandler(landcover);
       registerSourceHandler("landcover", landcover::processLandcover);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals(Places.LAYER_NAME)) {
+    if (layer.isEmpty() || layer.equals(Places.LAYER_NAME)) {
       var place = new Places(naturalEarthDb);
       registerHandler(place);
       registerSourceHandler("osm", place::processOsm);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals(Pois.LAYER_NAME)) {
+    if (layer.isEmpty() || layer.equals(Pois.LAYER_NAME)) {
       var poi = new Pois(qrankDb);
       registerHandler(poi);
       registerSourceHandler("osm", poi::processOsm);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals(Roads.LAYER_NAME)) {
+    if (layer.isEmpty() || layer.equals(Roads.LAYER_NAME)) {
       var roads = new Roads(countryCoder);
       registerHandler(roads);
       registerSourceHandler("osm", roads::processOsm);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals(Transit.LAYER_NAME)) {
+    if (layer.isEmpty() || layer.equals(Transit.LAYER_NAME)) {
       var transit = new Transit();
       registerHandler(transit);
       registerSourceHandler("osm", transit::processOsm);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals(Water.LAYER_NAME)) {
+    if (layer.isEmpty() || layer.equals(Water.LAYER_NAME)) {
       var water = new Water();
       registerHandler(water);
       registerSourceHandler("osm", water::processOsm);
@@ -89,7 +89,7 @@ public class Basemap extends ForwardingProfile {
       registerSourceHandler("ne", water::processNe);
     }
 
-    if (renderOnly.isEmpty() || renderOnly.equals(Earth.LAYER_NAME)) {
+    if (layer.isEmpty() || layer.equals(Earth.LAYER_NAME)) {
       var earth = new Earth();
       registerHandler(earth);
 
@@ -194,7 +194,7 @@ public class Basemap extends ForwardingProfile {
           Paths.get(clipArg));
     }
 
-    List<String> renderOnlyOptions = List.of(
+    List<String> availableLayers = List.of(
       Boundaries.LAYER_NAME,
       Buildings.LAYER_NAME,
       Landuse.LAYER_NAME,
@@ -207,17 +207,17 @@ public class Basemap extends ForwardingProfile {
       Earth.LAYER_NAME
     );
 
-    String renderOnly = args.getString("render_only",
-      "Render only a single layer. Possible values are: " + String.join(", ", renderOnlyOptions), "");
-    if (!(renderOnly.isEmpty() || renderOnlyOptions.contains(renderOnly))) {
-      System.err.println("Error: --render_only=" + renderOnly + " is not a valid option. Possible values are: " +
-        String.join(", ", renderOnlyOptions));
+    String layer = args.getString("layer",
+      "Process only a single layer. Possible values are: " + String.join(", ", availableLayers), "");
+    if (!(layer.isEmpty() || availableLayers.contains(layer))) {
+      System.err.println("Error: --layer=" + layer + " is not a valid option. Possible values are: " +
+        String.join(", ", availableLayers));
       System.exit(1);
     }
 
     fontRegistry.loadFontBundle("NotoSansDevanagari-Regular", "1", "Devanagari");
 
-    planetiler.setProfile(new Basemap(naturalEarthDb, qrankDb, countryCoder, clip, renderOnly))
+    planetiler.setProfile(new Basemap(naturalEarthDb, qrankDb, countryCoder, clip, layer))
       .setOutput(Path.of(area + ".pmtiles"))
       .run();
   }

--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -29,53 +29,73 @@ import java.util.Map;
 
 public class Basemap extends ForwardingProfile {
 
-  public Basemap(NaturalEarthDb naturalEarthDb, QrankDb qrankDb, CountryCoder countryCoder, Clip clip) {
+  public Basemap(NaturalEarthDb naturalEarthDb, QrankDb qrankDb, CountryCoder countryCoder, Clip clip, String renderOnly) {
 
-    var admin = new Boundaries();
-    registerHandler(admin);
-    registerSourceHandler("osm", admin::processOsm);
-    registerSourceHandler("ne", admin::processNe);
+    if (renderOnly.isEmpty() || renderOnly.equals("Boundaries")) {
+      var admin = new Boundaries();
+      registerHandler(admin);
+      registerSourceHandler("osm", admin::processOsm);
+      registerSourceHandler("ne", admin::processNe);
+    }
 
-    var buildings = new Buildings();
-    registerHandler(buildings);
-    registerSourceHandler("osm", buildings::processOsm);
+    if (renderOnly.isEmpty() || renderOnly.equals("Buildings")) {
+      var buildings = new Buildings();
+      registerHandler(buildings);
+      registerSourceHandler("osm", buildings::processOsm);
+    }
 
-    var landuse = new Landuse();
-    registerHandler(landuse);
-    registerSourceHandler("osm", landuse::processOsm);
+    if (renderOnly.isEmpty() || renderOnly.equals("Landuse")) {
+      var landuse = new Landuse();
+      registerHandler(landuse);
+      registerSourceHandler("osm", landuse::processOsm);
+    }
 
-    var landcover = new Landcover();
-    registerHandler(landcover);
-    registerSourceHandler("landcover", landcover::processLandcover);
+    if (renderOnly.isEmpty() || renderOnly.equals("Landcover")) {
+      var landcover = new Landcover();
+      registerHandler(landcover);
+      registerSourceHandler("landcover", landcover::processLandcover);
+    }
 
-    var place = new Places(naturalEarthDb);
-    registerHandler(place);
-    registerSourceHandler("osm", place::processOsm);
+    if (renderOnly.isEmpty() || renderOnly.equals("Places")) {
+      var place = new Places(naturalEarthDb);
+      registerHandler(place);
+      registerSourceHandler("osm", place::processOsm);
+    }
 
-    var poi = new Pois(qrankDb);
-    registerHandler(poi);
-    registerSourceHandler("osm", poi::processOsm);
+    if (renderOnly.isEmpty() || renderOnly.equals("Pois")) {
+      var poi = new Pois(qrankDb);
+      registerHandler(poi);
+      registerSourceHandler("osm", poi::processOsm);
+    }
 
-    var roads = new Roads(countryCoder);
-    registerHandler(roads);
-    registerSourceHandler("osm", roads::processOsm);
+    if (renderOnly.isEmpty() || renderOnly.equals("Roads")) {
+      var roads = new Roads(countryCoder);
+      registerHandler(roads);
+      registerSourceHandler("osm", roads::processOsm);
+    }
 
-    var transit = new Transit();
-    registerHandler(transit);
-    registerSourceHandler("osm", transit::processOsm);
+    if (renderOnly.isEmpty() || renderOnly.equals("Transit")) {
+      var transit = new Transit();
+      registerHandler(transit);
+      registerSourceHandler("osm", transit::processOsm);
+    }
 
-    var water = new Water();
-    registerHandler(water);
-    registerSourceHandler("osm", water::processOsm);
-    registerSourceHandler("osm_water", water::processPreparedOsm);
-    registerSourceHandler("ne", water::processNe);
+    if (renderOnly.isEmpty() || renderOnly.equals("Water")) {
+      var water = new Water();
+      registerHandler(water);
+      registerSourceHandler("osm", water::processOsm);
+      registerSourceHandler("osm_water", water::processPreparedOsm);
+      registerSourceHandler("ne", water::processNe);
+    }
 
-    var earth = new Earth();
-    registerHandler(earth);
-
-    registerSourceHandler("osm", earth::processOsm);
-    registerSourceHandler("osm_land", earth::processPreparedOsm);
-    registerSourceHandler("ne", earth::processNe);
+    if (renderOnly.isEmpty() || renderOnly.equals("Earth")) {
+      var earth = new Earth();
+      registerHandler(earth);
+  
+      registerSourceHandler("osm", earth::processOsm);
+      registerSourceHandler("osm_land", earth::processPreparedOsm);
+      registerSourceHandler("ne", earth::processNe);
+    }
 
     if (clip != null) {
       registerHandler(clip);
@@ -173,9 +193,27 @@ public class Basemap extends ForwardingProfile {
           Paths.get(clipArg));
     }
 
+    List<String> renderOnlyOptions = List.of(
+      "Boundaries", 
+      "Buildings", 
+      "Landuse", 
+      "Landcover", 
+      "Places", 
+      "Pois", 
+      "Roads", 
+      "Transit", 
+      "Water", 
+      "Earth"
+    );
+    String renderOnly = args.getString("render_only", "Render only a single layer. Possible values are: " + String.join(", ", renderOnlyOptions), "");
+    if (!(renderOnly.isEmpty() || renderOnlyOptions.contains(renderOnly))) {
+      System.err.println("Error: --render_only=\"" + renderOnly + "\" is not a valid option. Possible values are: " + String.join(", ", renderOnlyOptions));
+      System.exit(1);
+    }
+
     fontRegistry.loadFontBundle("NotoSansDevanagari-Regular", "1", "Devanagari");
 
-    planetiler.setProfile(new Basemap(naturalEarthDb, qrankDb, countryCoder, clip))
+    planetiler.setProfile(new Basemap(naturalEarthDb, qrankDb, countryCoder, clip, renderOnly))
       .setOutput(Path.of(area + ".pmtiles"))
       .run();
   }

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Boundaries.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Boundaries.java
@@ -14,11 +14,13 @@ import java.util.List;
 import java.util.OptionalInt;
 
 public class Boundaries implements ForwardingProfile.OsmRelationPreprocessor,
-  ForwardingProfile.LayerPostProcesser {
+  ForwardingProfile.LayerPostProcessor {
+
+  public static final String LAYER_NAME = "boundaries";
 
   @Override
   public String name() {
-    return "boundaries";
+    return LAYER_NAME;
   }
 
   public void processNe(SourceFeature sf, FeatureCollector features) {

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Buildings.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Buildings.java
@@ -18,14 +18,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-public class Buildings implements ForwardingProfile.LayerPostProcesser {
+public class Buildings implements ForwardingProfile.LayerPostProcessor {
 
   static final String HEIGHT_KEY = "height";
   static final String MIN_HEIGHT_KEY = "min_height";
 
+  public static final String LAYER_NAME = "buildings";
+
   @Override
   public String name() {
-    return "buildings";
+    return LAYER_NAME;
   }
 
   public record Height(Double height, Double min_height) {}

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
@@ -11,10 +11,13 @@ import com.protomaps.basemap.names.OsmNames;
 import java.util.List;
 import org.locationtech.jts.geom.Point;
 
-public class Earth implements ForwardingProfile.LayerPostProcesser {
+public class Earth implements ForwardingProfile.LayerPostProcessor {
+
+  public static final String LAYER_NAME = "earth";
+
   @Override
   public String name() {
-    return "earth";
+    return LAYER_NAME;
   }
 
   public void processPreparedOsm(SourceFeature ignoredSf, FeatureCollector features) {

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
@@ -9,7 +9,7 @@ import com.protomaps.basemap.feature.FeatureId;
 import java.util.List;
 import java.util.Map;
 
-public class Landcover implements ForwardingProfile.LayerPostProcesser {
+public class Landcover implements ForwardingProfile.LayerPostProcessor {
 
   static final Map<String, String> kindMapping = Map.of("urban", "urban_area", "crop", "farmland", "grass", "grassland",
     "trees", "forest", "snow", "glacier", "shrub", "scrub");

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
@@ -32,9 +32,11 @@ public class Landcover implements ForwardingProfile.LayerPostProcesser {
       .setMinPixelSize(0.0);
   }
 
+  public static final String LAYER_NAME = "landcover";
+
   @Override
   public String name() {
-    return "landcover";
+    return LAYER_NAME;
   }
 
   @Override

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
@@ -10,7 +10,7 @@ import com.protomaps.basemap.feature.FeatureId;
 import com.protomaps.basemap.postprocess.Area;
 import java.util.List;
 
-public class Landuse implements ForwardingProfile.LayerPostProcesser {
+public class Landuse implements ForwardingProfile.LayerPostProcessor {
 
   public void processOsm(SourceFeature sf, FeatureCollector features) {
     if (sf.canBePolygon() && (sf.hasTag("aeroway", "aerodrome", "runway") ||
@@ -166,9 +166,11 @@ public class Landuse implements ForwardingProfile.LayerPostProcesser {
     }
   }
 
+  public static final String LAYER_NAME = "landuse";
+
   @Override
   public String name() {
-    return "landuse";
+    return LAYER_NAME;
   }
 
   @Override

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class Places implements ForwardingProfile.LayerPostProcesser {
+public class Places implements ForwardingProfile.LayerPostProcessor {
 
   private NaturalEarthDb naturalEarthDb;
 
@@ -23,9 +23,11 @@ public class Places implements ForwardingProfile.LayerPostProcesser {
     this.naturalEarthDb = naturalEarthDb;
   }
 
+  public static final String LAYER_NAME = "places";
+
   @Override
   public String name() {
-    return "places";
+    return LAYER_NAME;
   }
 
   private final AtomicInteger placeNumber = new AtomicInteger(0);

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -14,7 +14,7 @@ import com.protomaps.basemap.feature.QrankDb;
 import com.protomaps.basemap.names.OsmNames;
 import java.util.List;
 
-public class Pois implements ForwardingProfile.LayerPostProcesser {
+public class Pois implements ForwardingProfile.LayerPostProcessor {
 
   private QrankDb qrankDb;
 
@@ -22,9 +22,11 @@ public class Pois implements ForwardingProfile.LayerPostProcesser {
     this.qrankDb = qrankDb;
   }
 
+  public static final String LAYER_NAME = "pois";
+
   @Override
   public String name() {
-    return "pois";
+    return LAYER_NAME;
   }
 
   private static final double WORLD_AREA_FOR_70K_SQUARE_METERS =

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -15,7 +15,7 @@ import com.protomaps.basemap.locales.US;
 import com.protomaps.basemap.names.OsmNames;
 import java.util.*;
 
-public class Roads implements ForwardingProfile.LayerPostProcesser {
+public class Roads implements ForwardingProfile.LayerPostProcessor {
 
   private CountryCoder countryCoder;
 
@@ -23,9 +23,11 @@ public class Roads implements ForwardingProfile.LayerPostProcesser {
     this.countryCoder = countryCoder;
   }
 
+  public static final String LAYER_NAME = "roads";
+
   @Override
   public String name() {
-    return "roads";
+    return LAYER_NAME;
   }
 
   // Hardcoded to US for now

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Transit.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Transit.java
@@ -6,11 +6,13 @@ import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.reader.SourceFeature;
 import java.util.List;
 
-public class Transit implements ForwardingProfile.LayerPostProcesser {
+public class Transit implements ForwardingProfile.LayerPostProcessor {
+
+  public static final String LAYER_NAME = "transit";
 
   @Override
   public String name() {
-    return "transit";
+    return LAYER_NAME;
   }
 
   public void processOsm(SourceFeature sf, FeatureCollector features) {}

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -19,6 +19,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
     Math.pow(GeoUtils.metersToPixelAtEquator(0, Math.sqrt(70_000)) / 256d, 2);
 
   public static final String LAYER_NAME = "water";
+
   @Override
   public String name() {
     return LAYER_NAME;

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -13,14 +13,15 @@ import com.protomaps.basemap.names.NeNames;
 import com.protomaps.basemap.names.OsmNames;
 import java.util.List;
 
-public class Water implements ForwardingProfile.LayerPostProcesser {
+public class Water implements ForwardingProfile.LayerPostProcessor {
 
   private static final double WORLD_AREA_FOR_70K_SQUARE_METERS =
     Math.pow(GeoUtils.metersToPixelAtEquator(0, Math.sqrt(70_000)) / 256d, 2);
 
+  public static final String LAYER_NAME = "water";
   @Override
   public String name() {
-    return "water";
+    return LAYER_NAME;
   }
 
   public void processPreparedOsm(SourceFeature ignoredSf, FeatureCollector features) {

--- a/tiles/src/test/java/com/protomaps/basemap/layers/LayerTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/LayerTest.java
@@ -24,7 +24,7 @@ abstract class LayerTest {
     List.of(new NaturalEarthDb.NeAdmin1StateProvince("California", "US-CA", "Q2", 5.0, 8.0)),
     List.of(new NaturalEarthDb.NePopulatedPlace("San Francisco", "Q3", 9.0, 2))
   );
-  final Basemap profile = new Basemap(naturalEarthDb, null, null, null);
+  final Basemap profile = new Basemap(naturalEarthDb, null, null, null, "");
 
   static void assertFeatures(int zoom, List<Map<String, Object>> expected, Iterable<FeatureCollector.Feature> actual) {
     var expectedList = expected.stream().toList();


### PR DESCRIPTION
Adds a `--layer` cli config option which allows you to process only a single layer. For example, to do only the roads you can use
```
--layer=roads
```
