### PR TITLE
Avoid variable shadowing in house number code

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Buildings.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Buildings.java
@@ -100,14 +100,14 @@ public class Buildings implements ForwardingProfile.LayerPostProcesser {
     }
 
     if (sf.hasTag("addr:housenumber")) {
-      FeatureCollector.Feature feature = null;
+      FeatureCollector.Feature housenumberFeature = null;
       if (sf.isPoint()) {
-        feature = features.point(this.name());
+        housenumberFeature = features.point(this.name());
       } else if (sf.canBePolygon()) {
-        feature = features.centroid(this.name());
+        housenumberFeature = features.centroid(this.name());
       }
-      if (feature != null) {
-        feature
+      if (housenumberFeature != null) {
+        housenumberFeature
           .setId(FeatureId.create(sf))
           .setAttr("addr_housenumber", sf.getString("addr:housenumber"))
           .setAttr("addr_street", sf.getString("addr:street"))


### PR DESCRIPTION
No functional change, just avoid shadowing the variable `feature` in the buildings layer.
