### PR TITLE
Fix trunk link minzoom

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -119,6 +119,7 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
           minZoomShieldText = 10;
         } else if (highway.equals("trunk_link")) {
           minZoomShieldText = 12;
+          minZoom = hasOverride ? 7 : 6;
         } else {
           minZoomShieldText = 13;
         }


### PR DESCRIPTION
When writing the road relation pull request I forgot that trunk_link and trunk should have the same minzoom, similar to motorway and motorway_link...
