### PR TITLE
roads unittests

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -239,60 +239,60 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
 
     // non-highway features
     // todo: exclude railway stations, levels
-    if (sf.canBeLine() && (sf.hasTag("railway") ||
-      sf.hasTag("aerialway", "cable_car") ||
-      sf.hasTag("man_made", "pier") ||
-      sf.hasTag("route", "ferry") ||
-      sf.hasTag("aeroway", "runway", "taxiway")) &&
+    if (sf.canBeLine() && (sf.hasTag("railway") || //
+      sf.hasTag("aerialway", "cable_car") || //
+      sf.hasTag("man_made", "pier") || //
+      sf.hasTag("route", "ferry") || //
+      sf.hasTag("aeroway", "runway", "taxiway")) && //
       (!sf.hasTag("building") /* see https://github.com/protomaps/basemaps/issues/249 */) &&
       (!sf.hasTag("railway", "abandoned", "razed", "demolished", "removed", "construction", "platform", "proposed"))) {
 
       int minZoom = 11;
 
       if (sf.hasTag("aeroway", "runway")) {
-        minZoom = 9;
+        minZoom = 9; //
       } else if (sf.hasTag("aeroway", "taxiway")) {
-        minZoom = 10;
+        minZoom = 10; //
       } else if (sf.hasTag("service", "yard", "siding", "crossover")) {
         minZoom = 13;
       } else if (sf.hasTag("man_made", "pier")) {
-        minZoom = 13;
+        minZoom = 13; //
       }
 
       String kind = "other";
       String kindDetail = "";
       if (sf.hasTag("aeroway")) {
-        kind = "aeroway";
-        kindDetail = sf.getString("aeroway");
+        kind = "aeroway"; //
+        kindDetail = sf.getString("aeroway"); //
       } else if (sf.hasTag("railway", "disused", "funicular", "light_rail", "miniature", "monorail", "narrow_gauge",
         "preserved", "subway", "tram")) {
-        kind = "rail";
-        kindDetail = sf.getString("railway");
-        minZoom = 14;
+        kind = "rail"; //
+        kindDetail = sf.getString("railway"); //
+        minZoom = 14; //
 
         if (sf.hasTag("railway", "disused")) {
-          minZoom = 15;
+          minZoom = 15; //
         }
       } else if (sf.hasTag("railway")) {
-        kind = "rail";
-        kindDetail = sf.getString("railway");
+        kind = "rail"; //
+        kindDetail = sf.getString("railway"); //
 
         if (kindDetail.equals("service")) {
-          minZoom = 13;
+          minZoom = 13; //
 
           // eg a rail yard
           if (sf.hasTag("service")) {
-            minZoom = 14;
+            minZoom = 14; //
           }
         }
       } else if (sf.hasTag("route", "ferry")) {
-        kind = "ferry";
+        kind = "ferry"; //
       } else if (sf.hasTag("man_made", "pier")) {
-        kind = "path";
-        kindDetail = "pier";
+        kind = "path"; //
+        kindDetail = "pier"; //
       } else if (sf.hasTag("aerialway")) {
-        kind = "aerialway";
-        kindDetail = sf.getString("aerialway");
+        kind = "aerialway"; //
+        kindDetail = sf.getString("aerialway"); //
       }
 
       var feature = features.line(this.name())

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -96,8 +96,8 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
       if (highway.equals("motorway") || highway.equals("motorway_link")) {
         // TODO: (nvkelso 20230622) Use Natural Earth for low zoom roads at zoom 5 and earlier
         //       as normally OSM roads would start at 6, but we start at 3 to match Protomaps v2
-        kind = "highway";
-        minZoom = hasOverride ? 7 : 3;
+        kind = "highway"; //
+        minZoom = hasOverride ? 7 : 3; //
 
         if (highway.equals("motorway")) {
           minZoomShieldText = 7;
@@ -109,11 +109,11 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
       } else if (highway.equals("trunk") || highway.equals("trunk_link") || highway.equals("primary") ||
         highway.equals("primary_link")) {
         kind = "major_road";
-        minZoom = 7;
+        minZoom = 7; //
 
         if (highway.equals("trunk")) {
           // Just trunk earlier zoom, otherwise road network looks choppy just with motorways then
-          minZoom = hasOverride ? 7 : 6;
+          minZoom = hasOverride ? 7 : 6; //
           minZoomShieldText = 8;
         } else if (highway.equals("primary")) {
           minZoomShieldText = 10;
@@ -126,8 +126,8 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
         minZoomNames = 12;
       } else if (highway.equals("secondary") || highway.equals("secondary_link") || highway.equals("tertiary") ||
         highway.equals("tertiary_link")) {
-        kind = "major_road";
-        minZoom = 9;
+        kind = "major_road"; //
+        minZoom = 9; //
 
         if (highway.equals("secondary")) {
           minZoomShieldText = 11;
@@ -141,14 +141,14 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
         }
       } else if (highway.equals("residential") || highway.equals("service") || highway.equals("unclassified") ||
         highway.equals("road") || highway.equals("raceway")) {
-        kind = "minor_road";
-        minZoom = 12;
+        kind = "minor_road"; //
+        minZoom = 12; //
         minZoomShieldText = 12;
         minZoomNames = 14;
 
         if (highway.equals("service")) {
-          kindDetail = "service";
-          minZoom = 13;
+          kindDetail = "service"; //
+          minZoom = 13; //
 
           // push down "alley", "driveway", "parking_aisle", "drive-through" & etc
           if (sf.hasTag("service")) {

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -158,21 +158,21 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
         }
       } else if (sf.hasTag("highway", "pedestrian", "track", "path", "cycleway", "bridleway", "footway",
         "steps", "corridor")) {
-        kind = "path";
-        kindDetail = highway;
-        minZoom = 12;
+        kind = "path"; // 
+        kindDetail = highway; //
+        minZoom = 12; //
         minZoomShieldText = 12;
         minZoomNames = 14;
 
         if (sf.hasTag("highway", "path", "cycleway", "bridleway", "footway", "steps")) {
-          minZoom = 13;
+          minZoom = 13; //
         }
         if (sf.hasTag("footway", "sidewalk", "crossing")) {
           minZoom = 14;
           kindDetail = sf.getString("footway", "");
         }
         if (sf.hasTag("highway", "corridor")) {
-          minZoom = 14;
+          minZoom = 14; //
         }
       } else {
         kind = "other"; //

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -56,10 +56,10 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
   public void processOsm(SourceFeature sf, FeatureCollector features) {
     if (sf.canBeLine() && sf.hasTag("highway") &&
       !(sf.hasTag("highway", "proposed", "abandoned", "razed", "demolished", "removed", "construction", "elevator"))) {
-      String kind = "other";
-      String kindDetail = "";
-      int minZoom = 15;
-      int maxZoom = 15;
+      String kind = "other"; // 
+      String kindDetail = ""; //
+      int minZoom = 15; //
+      int maxZoom = 15; //
       int minZoomShieldText = 10;
       int minZoomNames = 14;
 
@@ -175,9 +175,9 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
           minZoom = 14;
         }
       } else {
-        kind = "other";
-        kindDetail = sf.getString("service", "");
-        minZoom = 14;
+        kind = "other"; //
+        kindDetail = sf.getString("service", ""); //
+        minZoom = 14; //
         minZoomShieldText = 14;
         minZoomNames = 14;
       }

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -244,8 +244,8 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
       sf.hasTag("man_made", "pier") || //
       sf.hasTag("route", "ferry") || //
       sf.hasTag("aeroway", "runway", "taxiway")) && //
-      (!sf.hasTag("building") /* see https://github.com/protomaps/basemaps/issues/249 */) &&
-      (!sf.hasTag("railway", "abandoned", "razed", "demolished", "removed", "construction", "platform", "proposed"))) {
+      (!sf.hasTag("building") /* see https://github.com/protomaps/basemaps/issues/249 */) && // 
+      (!sf.hasTag("railway", "abandoned", "razed", "demolished", "removed", "construction", "platform", "proposed"))) { //
 
       int minZoom = 11;
 
@@ -254,7 +254,7 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
       } else if (sf.hasTag("aeroway", "taxiway")) {
         minZoom = 10; //
       } else if (sf.hasTag("service", "yard", "siding", "crossover")) {
-        minZoom = 13;
+        minZoom = 13; //
       } else if (sf.hasTag("man_made", "pier")) {
         minZoom = 13; //
       }

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -357,5 +357,4 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
 
     return items;
   }
-
 }

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -152,8 +152,8 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
 
           // push down "alley", "driveway", "parking_aisle", "drive-through" & etc
           if (sf.hasTag("service")) {
-            minZoom = 14;
-            service = sf.getString("service");
+            minZoom = 14; //
+            service = sf.getString("service"); //
           }
         }
       } else if (sf.hasTag("highway", "pedestrian", "track", "path", "cycleway", "bridleway", "footway",
@@ -168,8 +168,8 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
           minZoom = 13; //
         }
         if (sf.hasTag("footway", "sidewalk", "crossing")) {
-          minZoom = 14;
-          kindDetail = sf.getString("footway", "");
+          minZoom = 14; //
+          kindDetail = sf.getString("footway", ""); //
         }
         if (sf.hasTag("highway", "corridor")) {
           minZoom = 14; //

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -56,10 +56,10 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
   public void processOsm(SourceFeature sf, FeatureCollector features) {
     if (sf.canBeLine() && sf.hasTag("highway") &&
       !(sf.hasTag("highway", "proposed", "abandoned", "razed", "demolished", "removed", "construction", "elevator"))) {
-      String kind = "other"; // 
-      String kindDetail = ""; //
-      int minZoom = 15; //
-      int maxZoom = 15; //
+      String kind = "other";
+      String kindDetail = "";
+      int minZoom = 15;
+      int maxZoom = 15;
       int minZoomShieldText = 10;
       int minZoomNames = 14;
 
@@ -96,8 +96,8 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
       if (highway.equals("motorway") || highway.equals("motorway_link")) {
         // TODO: (nvkelso 20230622) Use Natural Earth for low zoom roads at zoom 5 and earlier
         //       as normally OSM roads would start at 6, but we start at 3 to match Protomaps v2
-        kind = "highway"; //
-        minZoom = hasOverride ? 7 : 3; //
+        kind = "highway";
+        minZoom = hasOverride ? 7 : 3;
 
         if (highway.equals("motorway")) {
           minZoomShieldText = 7;
@@ -109,11 +109,11 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
       } else if (highway.equals("trunk") || highway.equals("trunk_link") || highway.equals("primary") ||
         highway.equals("primary_link")) {
         kind = "major_road";
-        minZoom = 7; //
+        minZoom = 7;
 
         if (highway.equals("trunk")) {
           // Just trunk earlier zoom, otherwise road network looks choppy just with motorways then
-          minZoom = hasOverride ? 7 : 6; //
+          minZoom = hasOverride ? 7 : 6;
           minZoomShieldText = 8;
         } else if (highway.equals("primary")) {
           minZoomShieldText = 10;
@@ -126,8 +126,8 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
         minZoomNames = 12;
       } else if (highway.equals("secondary") || highway.equals("secondary_link") || highway.equals("tertiary") ||
         highway.equals("tertiary_link")) {
-        kind = "major_road"; //
-        minZoom = 9; //
+        kind = "major_road";
+        minZoom = 9;
 
         if (highway.equals("secondary")) {
           minZoomShieldText = 11;
@@ -141,53 +141,53 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
         }
       } else if (highway.equals("residential") || highway.equals("service") || highway.equals("unclassified") ||
         highway.equals("road") || highway.equals("raceway")) {
-        kind = "minor_road"; //
-        minZoom = 12; //
+        kind = "minor_road";
+        minZoom = 12;
         minZoomShieldText = 12;
         minZoomNames = 14;
 
         if (highway.equals("service")) {
-          kindDetail = "service"; //
-          minZoom = 13; //
+          kindDetail = "service";
+          minZoom = 13;
 
           // push down "alley", "driveway", "parking_aisle", "drive-through" & etc
           if (sf.hasTag("service")) {
-            minZoom = 14; //
-            service = sf.getString("service"); //
+            minZoom = 14;
+            service = sf.getString("service");
           }
         }
       } else if (sf.hasTag("highway", "pedestrian", "track", "path", "cycleway", "bridleway", "footway",
         "steps", "corridor")) {
-        kind = "path"; // 
-        kindDetail = highway; //
-        minZoom = 12; //
+        kind = "path";
+        kindDetail = highway;
+        minZoom = 12;
         minZoomShieldText = 12;
         minZoomNames = 14;
 
         if (sf.hasTag("highway", "path", "cycleway", "bridleway", "footway", "steps")) {
-          minZoom = 13; //
+          minZoom = 13;
         }
         if (sf.hasTag("footway", "sidewalk", "crossing")) {
-          minZoom = 14; //
-          kindDetail = sf.getString("footway", ""); //
+          minZoom = 14;
+          kindDetail = sf.getString("footway", "");
         }
         if (sf.hasTag("highway", "corridor")) {
-          minZoom = 14; //
+          minZoom = 14;
         }
       } else {
-        kind = "other"; //
-        kindDetail = sf.getString("service", ""); //
-        minZoom = 14; //
+        kind = "other";
+        kindDetail = sf.getString("service", "");
+        minZoom = 14;
         minZoomShieldText = 14;
         minZoomNames = 14;
       }
 
       if (hasOverride) {
         if (BRoad) {
-          minZoom = 6; // 
+          minZoom = 6;
         }
         if (ARoad) {
-          minZoom = 3; //
+          minZoom = 3;
         }
       }
 
@@ -208,9 +208,9 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
         .setZoomRange(minZoom, maxZoom);
 
       if (!kindDetail.isEmpty()) {
-        feat.setAttr("kind_detail", kindDetail); //
+        feat.setAttr("kind_detail", kindDetail);
       } else {
-        feat.setAttr("kind_detail", highway); //
+        feat.setAttr("kind_detail", highway);
       }
 
       // Core OSM tags for different kinds of places
@@ -239,60 +239,60 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
 
     // non-highway features
     // todo: exclude railway stations, levels
-    if (sf.canBeLine() && (sf.hasTag("railway") || //
-      sf.hasTag("aerialway", "cable_car") || //
-      sf.hasTag("man_made", "pier") || //
-      sf.hasTag("route", "ferry") || //
-      sf.hasTag("aeroway", "runway", "taxiway")) && //
-      (!sf.hasTag("building") /* see https://github.com/protomaps/basemaps/issues/249 */) && // 
-      (!sf.hasTag("railway", "abandoned", "razed", "demolished", "removed", "construction", "platform", "proposed"))) { //
+    if (sf.canBeLine() && (sf.hasTag("railway") ||
+      sf.hasTag("aerialway", "cable_car") ||
+      sf.hasTag("man_made", "pier") ||
+      sf.hasTag("route", "ferry") ||
+      sf.hasTag("aeroway", "runway", "taxiway")) &&
+      (!sf.hasTag("building") /* see https://github.com/protomaps/basemaps/issues/249 */) &&
+      (!sf.hasTag("railway", "abandoned", "razed", "demolished", "removed", "construction", "platform", "proposed"))) {
 
       int minZoom = 11;
 
       if (sf.hasTag("aeroway", "runway")) {
-        minZoom = 9; //
+        minZoom = 9;
       } else if (sf.hasTag("aeroway", "taxiway")) {
-        minZoom = 10; //
+        minZoom = 10;
       } else if (sf.hasTag("service", "yard", "siding", "crossover")) {
-        minZoom = 13; //
+        minZoom = 13;
       } else if (sf.hasTag("man_made", "pier")) {
-        minZoom = 13; //
+        minZoom = 13;
       }
 
       String kind = "other";
       String kindDetail = "";
       if (sf.hasTag("aeroway")) {
-        kind = "aeroway"; //
-        kindDetail = sf.getString("aeroway"); //
+        kind = "aeroway";
+        kindDetail = sf.getString("aeroway");
       } else if (sf.hasTag("railway", "disused", "funicular", "light_rail", "miniature", "monorail", "narrow_gauge",
         "preserved", "subway", "tram")) {
-        kind = "rail"; //
-        kindDetail = sf.getString("railway"); //
-        minZoom = 14; //
+        kind = "rail";
+        kindDetail = sf.getString("railway");
+        minZoom = 14;
 
         if (sf.hasTag("railway", "disused")) {
-          minZoom = 15; //
+          minZoom = 15;
         }
       } else if (sf.hasTag("railway")) {
-        kind = "rail"; //
-        kindDetail = sf.getString("railway"); //
+        kind = "rail";
+        kindDetail = sf.getString("railway");
 
         if (kindDetail.equals("service")) {
-          minZoom = 13; //
+          minZoom = 13;
 
           // eg a rail yard
           if (sf.hasTag("service")) {
-            minZoom = 14; //
+            minZoom = 14;
           }
         }
       } else if (sf.hasTag("route", "ferry")) {
-        kind = "ferry"; //
+        kind = "ferry";
       } else if (sf.hasTag("man_made", "pier")) {
-        kind = "path"; //
-        kindDetail = "pier"; //
+        kind = "path";
+        kindDetail = "pier";
       } else if (sf.hasTag("aerialway")) {
-        kind = "aerialway"; //
-        kindDetail = sf.getString("aerialway"); //
+        kind = "aerialway";
+        kindDetail = sf.getString("aerialway");
       }
 
       var feature = features.line(this.name())

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -184,10 +184,10 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
 
       if (hasOverride) {
         if (BRoad) {
-          minZoom = 6;
+          minZoom = 6; // 
         }
         if (ARoad) {
-          minZoom = 3;
+          minZoom = 3; //
         }
       }
 
@@ -208,9 +208,9 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
         .setZoomRange(minZoom, maxZoom);
 
       if (!kindDetail.isEmpty()) {
-        feat.setAttr("kind_detail", kindDetail);
+        feat.setAttr("kind_detail", kindDetail); //
       } else {
-        feat.setAttr("kind_detail", highway);
+        feat.setAttr("kind_detail", highway); //
       }
 
       // Core OSM tags for different kinds of places

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -356,4 +356,5 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
 
     return items;
   }
+
 }

--- a/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
@@ -181,6 +181,8 @@ class RoadsTest extends LayerTest {
 
   @Test
   void testHighwayMotorway() {
+
+    // generic highway=motorway
     assertFeatures(12,
       List.of(Map.of("kind", "highway",
         "kind_detail", "motorway",
@@ -189,12 +191,41 @@ class RoadsTest extends LayerTest {
       processWith("highway", "motorway")
     );
 
+
+    // US highway=motorway
+    assertFeatures(12,
+      List.of(Map.of("kind", "highway",
+        "kind_detail", "motorway",
+        "_minzoom", 7
+      )),
+      processWithRelationAndCoords("",
+        -104.97235, 39.73867, -105.260503, 40.010771,
+        "highway", "motorway"
+      )
+    );
+
+    // US highway=motorway with relation US:US
+    assertFeatures(12,
+      List.of(Map.of("kind", "highway",
+        "kind_detail", "motorway",
+        "_minzoom", 6
+      )),
+      processWithRelationAndCoords("US:US",
+        -104.97235, 39.73867, -105.260503, 40.010771,
+        "highway", "motorway"
+      )
+    );
+
+    // US highway=motorway with relation US:I
     assertFeatures(12,
       List.of(Map.of("kind", "highway",
         "kind_detail", "motorway",
         "_minzoom", 3
       )),
-      processWith("highway", "motorway")
+      processWithRelationAndCoords("US:I",
+        -104.97235, 39.73867, -105.260503, 40.010771,
+        "highway", "motorway"
+      )
     );
   }
 }

--- a/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
@@ -12,22 +12,37 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class RoadsTest extends LayerTest {
+  private FeatureCollector processWith(String... arguments) {
+    Map<String, Object> tags = new HashMap<>();
+    List<String> argumentList = List.of(arguments);
+    if (argumentList.size() % 2 == 0) {
+      for (int i = 0; i < argumentList.size(); i += 2) {
+        tags.put(argumentList.get(i), argumentList.get(i + 1));
+      }
+    }
+    return process(SimpleFeature.create(
+      newLineString(0, 0, 1, 1),
+      tags,
+      "osm",
+      null,
+      0
+    ));
+  }
+
   @Test
   void simple() {
     assertFeatures(12,
-      List.of(Map.of("kind", "highway", "kind_detail", "motorway", "ref", "1", "network", "US:US",
-        "shield_text_length", 1)),
-      process(SimpleFeature.create(
-        newLineString(0, 0, 1, 1),
-        new HashMap<>(Map.of(
-          "layer", "1",
-          "highway", "motorway",
-          "ref", "US 1"
-        )),
-        "osm",
-        null,
-        0
-      )));
+      List.of(Map.of("kind", "highway",
+        "kind_detail", "motorway",
+        "ref", "1",
+        "network", "US:US",
+        "shield_text_length", 1
+      )),
+      processWith("layer", "1",
+        "highway", "motorway",
+        "ref", "US 1"
+      )
+    );
   }
 
   @Test

--- a/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
@@ -125,41 +125,20 @@ class RoadsTest extends LayerTest {
     );
   }
 
-  @Test
-  void testHighwayExcluded() {
+  @ParameterizedTest
+  @CsvSource({
+    "proposed",
+    "abandoned",
+    "razed",
+    "demolished",
+    "removed",
+    "construction",
+    "elevator"
+  })
+  void testHighwayExcluded(String highway) {
     assertFeatures(12,
       List.of(),
-      processWith("highway", "proposed")
-    );
-
-    assertFeatures(12,
-      List.of(),
-      processWith("highway", "abandoned")
-    );
-
-    assertFeatures(12,
-      List.of(),
-      processWith("highway", "razed")
-    );
-
-    assertFeatures(12,
-      List.of(),
-      processWith("highway", "demolished")
-    );
-
-    assertFeatures(12,
-      List.of(),
-      processWith("highway", "removed")
-    );
-
-    assertFeatures(12,
-      List.of(),
-      processWith("highway", "construction")
-    );
-
-    assertFeatures(12,
-      List.of(),
-      processWith("highway", "elevator")
+      processWith("highway", highway)
     );
   }
 

--- a/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
@@ -228,4 +228,154 @@ class RoadsTest extends LayerTest {
       )
     );
   }
+
+  @Test
+  void testHighwayMotorwayLink() {
+
+    // generic highway=motorway_link
+    assertFeatures(12,
+      List.of(Map.of("kind", "highway",
+        "kind_detail", "motorway_link",
+        "_minzoom", 3
+      )),
+      processWith("highway", "motorway_link")
+    );
+
+
+    // US highway=motorway_link
+    assertFeatures(12,
+      List.of(Map.of("kind", "highway",
+        "kind_detail", "motorway_link",
+        "_minzoom", 7
+      )),
+      processWithRelationAndCoords("",
+        -104.97235, 39.73867, -105.260503, 40.010771,
+        "highway", "motorway_link"
+      )
+    );
+
+    // US highway=motorway_link with relation US:US
+    assertFeatures(12,
+      List.of(Map.of("kind", "highway",
+        "kind_detail", "motorway_link",
+        "_minzoom", 6
+      )),
+      processWithRelationAndCoords("US:US",
+        -104.97235, 39.73867, -105.260503, 40.010771,
+        "highway", "motorway_link"
+      )
+    );
+
+    // US highway=motorway_link with relation US:I
+    assertFeatures(12,
+      List.of(Map.of("kind", "highway",
+        "kind_detail", "motorway_link",
+        "_minzoom", 3
+      )),
+      processWithRelationAndCoords("US:I",
+        -104.97235, 39.73867, -105.260503, 40.010771,
+        "highway", "motorway_link"
+      )
+    );
+  }
+
+  @Test
+  void testHighwayTrunk() {
+
+    // generic highway=trunk
+    assertFeatures(12,
+      List.of(Map.of("kind", "major_road",
+        "kind_detail", "trunk",
+        "_minzoom", 6
+      )),
+      processWith("highway", "trunk")
+    );
+
+
+    // US highway=trunk
+    assertFeatures(12,
+      List.of(Map.of("kind", "major_road",
+        "kind_detail", "trunk",
+        "_minzoom", 7
+      )),
+      processWithRelationAndCoords("",
+        -104.97235, 39.73867, -105.260503, 40.010771,
+        "highway", "trunk"
+      )
+    );
+
+    // US highway=trunk with relation US:US
+    assertFeatures(12,
+      List.of(Map.of("kind", "major_road",
+        "kind_detail", "trunk",
+        "_minzoom", 6
+      )),
+      processWithRelationAndCoords("US:US",
+        -104.97235, 39.73867, -105.260503, 40.010771,
+        "highway", "trunk"
+      )
+    );
+
+    // US highway=trunk with relation US:I
+    assertFeatures(12,
+      List.of(Map.of("kind", "major_road",
+        "kind_detail", "trunk",
+        "_minzoom", 3
+      )),
+      processWithRelationAndCoords("US:I",
+        -104.97235, 39.73867, -105.260503, 40.010771,
+        "highway", "trunk"
+      )
+    );
+  }
+
+  @Test
+  void testHighwayTrunkLink() {
+
+    // generic highway=trunk_link
+    assertFeatures(12,
+      List.of(Map.of("kind", "major_road",
+        "kind_detail", "trunk_link",
+        "_minzoom", 7
+      )),
+      processWith("highway", "trunk_link")
+    );
+
+
+    // US highway=trunk_link
+    assertFeatures(12,
+      List.of(Map.of("kind", "major_road",
+        "kind_detail", "trunk_link",
+        "_minzoom", 7
+      )),
+      processWithRelationAndCoords("",
+        -104.97235, 39.73867, -105.260503, 40.010771,
+        "highway", "trunk_link"
+      )
+    );
+
+    // US highway=trunk_link with relation US:US
+    assertFeatures(12,
+      List.of(Map.of("kind", "major_road",
+        "kind_detail", "trunk_link",
+        "_minzoom", 6
+      )),
+      processWithRelationAndCoords("US:US",
+        -104.97235, 39.73867, -105.260503, 40.010771,
+        "highway", "trunk_link"
+      )
+    );
+
+    // US highway=trunk_link with relation US:I
+    assertFeatures(12,
+      List.of(Map.of("kind", "major_road",
+        "kind_detail", "trunk_link",
+        "_minzoom", 3
+      )),
+      processWithRelationAndCoords("US:I",
+        -104.97235, 39.73867, -105.260503, 40.010771,
+        "highway", "trunk_link"
+      )
+    );
+  }
 }

--- a/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
@@ -200,7 +200,15 @@ class RoadsTest extends LayerTest {
     "residential, minor_road, residential, 12, 12",
     "unclassified, minor_road, unclassified, 12, 12",
     "road, minor_road, road, 12, 12",
-    "raceway, minor_road, raceway, 12, 12"
+    "raceway, minor_road, raceway, 12, 12",
+    "pedestrian, path, pedestrian, 12, 12",
+    "track, path, track, 12, 12",
+    "path, path, path, 13, 13",
+    "cycleway, path, cycleway, 13, 13",
+    "bridleway, path, bridleway, 13, 13",
+    "footway, path, footway, 13, 13",
+    "steps, path, steps, 13, 13",
+    "corridor, path, corridor, 14, 14",
   })
   void testHighways(String highway, String kind, String kindDetail, int genericMinZoom, int usMinZoom) {
 

--- a/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
@@ -166,7 +166,7 @@ class RoadsTest extends LayerTest {
     "motorway, highway, motorway, 3, 7",
     "motorway_link, highway, motorway_link, 3, 7",
     "trunk, major_road, trunk, 6, 7",
-    "trunk_link, major_road, trunk_link, 7, 7",
+    "trunk_link, major_road, trunk_link, 6, 7",
     "primary, major_road, primary, 7, 7",
     "primary_link, major_road, primary_link, 7, 7",
     "secondary, major_road, secondary, 9, 9",

--- a/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
@@ -10,6 +10,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.CsvSource;
+
 
 class RoadsTest extends LayerTest {
   private FeatureCollector processWith(String... arguments) {
@@ -179,202 +183,69 @@ class RoadsTest extends LayerTest {
     );
   }
 
-  @Test
-  void testHighwayMotorway() {
+  @ParameterizedTest
+  @CsvSource({
+    "motorway, highway, motorway, 3, 7",
+    "motorway_link, highway, motorway_link, 3, 7",
+    "trunk, major_road, trunk, 6, 7",
+    "trunk_link, major_road, trunk_link, 7, 7",
+    "primary, major_road, primary, 7, 7",
+    "primary_link, major_road, primary_link, 7, 7",
+    "secondary, major_road, secondary, 9, 9",
+    "secondary_link, major_road, secondary_link, 9, 9",
+    "tertiary, major_road, tertiary, 9, 9",
+    "tertiary_link, major_road, tertiary_link, 9, 9",
+    "residential, minor_road, residential, 12, 12",
+    "service, minor_road, service, 13, 13",
+    "residential, minor_road, residential, 12, 12",
+    "unclassified, minor_road, unclassified, 12, 12",
+    "road, minor_road, road, 12, 12",
+    "raceway, minor_road, raceway, 12, 12"
+  })
+  void testHighways(String highway, String kind, String kindDetail, int genericMinZoom, int usMinZoom) {
 
-    // generic highway=motorway
+    // generic
     assertFeatures(12,
-      List.of(Map.of("kind", "highway",
-        "kind_detail", "motorway",
-        "_minzoom", 3
+      List.of(Map.of("kind", kind,
+        "kind_detail", kindDetail,
+        "_minzoom", genericMinZoom
       )),
-      processWith("highway", "motorway")
+      processWith("highway", highway)
     );
 
-
-    // US highway=motorway
+    // US
     assertFeatures(12,
-      List.of(Map.of("kind", "highway",
-        "kind_detail", "motorway",
-        "_minzoom", 7
+      List.of(Map.of("kind", kind,
+        "kind_detail", kindDetail,
+        "_minzoom", usMinZoom
       )),
       processWithRelationAndCoords("",
         -104.97235, 39.73867, -105.260503, 40.010771,
-        "highway", "motorway"
+        "highway", highway
       )
     );
 
-    // US highway=motorway with relation US:US
+    // US with relation US:US
     assertFeatures(12,
-      List.of(Map.of("kind", "highway",
-        "kind_detail", "motorway",
+      List.of(Map.of("kind", kind,
+        "kind_detail", kindDetail,
         "_minzoom", 6
       )),
       processWithRelationAndCoords("US:US",
         -104.97235, 39.73867, -105.260503, 40.010771,
-        "highway", "motorway"
+        "highway", highway
       )
     );
 
-    // US highway=motorway with relation US:I
+    // US with relation US:I
     assertFeatures(12,
-      List.of(Map.of("kind", "highway",
-        "kind_detail", "motorway",
+      List.of(Map.of("kind", kind,
+        "kind_detail", kindDetail,
         "_minzoom", 3
       )),
       processWithRelationAndCoords("US:I",
         -104.97235, 39.73867, -105.260503, 40.010771,
-        "highway", "motorway"
-      )
-    );
-  }
-
-  @Test
-  void testHighwayMotorwayLink() {
-
-    // generic highway=motorway_link
-    assertFeatures(12,
-      List.of(Map.of("kind", "highway",
-        "kind_detail", "motorway_link",
-        "_minzoom", 3
-      )),
-      processWith("highway", "motorway_link")
-    );
-
-
-    // US highway=motorway_link
-    assertFeatures(12,
-      List.of(Map.of("kind", "highway",
-        "kind_detail", "motorway_link",
-        "_minzoom", 7
-      )),
-      processWithRelationAndCoords("",
-        -104.97235, 39.73867, -105.260503, 40.010771,
-        "highway", "motorway_link"
-      )
-    );
-
-    // US highway=motorway_link with relation US:US
-    assertFeatures(12,
-      List.of(Map.of("kind", "highway",
-        "kind_detail", "motorway_link",
-        "_minzoom", 6
-      )),
-      processWithRelationAndCoords("US:US",
-        -104.97235, 39.73867, -105.260503, 40.010771,
-        "highway", "motorway_link"
-      )
-    );
-
-    // US highway=motorway_link with relation US:I
-    assertFeatures(12,
-      List.of(Map.of("kind", "highway",
-        "kind_detail", "motorway_link",
-        "_minzoom", 3
-      )),
-      processWithRelationAndCoords("US:I",
-        -104.97235, 39.73867, -105.260503, 40.010771,
-        "highway", "motorway_link"
-      )
-    );
-  }
-
-  @Test
-  void testHighwayTrunk() {
-
-    // generic highway=trunk
-    assertFeatures(12,
-      List.of(Map.of("kind", "major_road",
-        "kind_detail", "trunk",
-        "_minzoom", 6
-      )),
-      processWith("highway", "trunk")
-    );
-
-
-    // US highway=trunk
-    assertFeatures(12,
-      List.of(Map.of("kind", "major_road",
-        "kind_detail", "trunk",
-        "_minzoom", 7
-      )),
-      processWithRelationAndCoords("",
-        -104.97235, 39.73867, -105.260503, 40.010771,
-        "highway", "trunk"
-      )
-    );
-
-    // US highway=trunk with relation US:US
-    assertFeatures(12,
-      List.of(Map.of("kind", "major_road",
-        "kind_detail", "trunk",
-        "_minzoom", 6
-      )),
-      processWithRelationAndCoords("US:US",
-        -104.97235, 39.73867, -105.260503, 40.010771,
-        "highway", "trunk"
-      )
-    );
-
-    // US highway=trunk with relation US:I
-    assertFeatures(12,
-      List.of(Map.of("kind", "major_road",
-        "kind_detail", "trunk",
-        "_minzoom", 3
-      )),
-      processWithRelationAndCoords("US:I",
-        -104.97235, 39.73867, -105.260503, 40.010771,
-        "highway", "trunk"
-      )
-    );
-  }
-
-  @Test
-  void testHighwayTrunkLink() {
-
-    // generic highway=trunk_link
-    assertFeatures(12,
-      List.of(Map.of("kind", "major_road",
-        "kind_detail", "trunk_link",
-        "_minzoom", 7
-      )),
-      processWith("highway", "trunk_link")
-    );
-
-
-    // US highway=trunk_link
-    assertFeatures(12,
-      List.of(Map.of("kind", "major_road",
-        "kind_detail", "trunk_link",
-        "_minzoom", 7
-      )),
-      processWithRelationAndCoords("",
-        -104.97235, 39.73867, -105.260503, 40.010771,
-        "highway", "trunk_link"
-      )
-    );
-
-    // US highway=trunk_link with relation US:US
-    assertFeatures(12,
-      List.of(Map.of("kind", "major_road",
-        "kind_detail", "trunk_link",
-        "_minzoom", 6
-      )),
-      processWithRelationAndCoords("US:US",
-        -104.97235, 39.73867, -105.260503, 40.010771,
-        "highway", "trunk_link"
-      )
-    );
-
-    // US highway=trunk_link with relation US:I
-    assertFeatures(12,
-      List.of(Map.of("kind", "major_road",
-        "kind_detail", "trunk_link",
-        "_minzoom", 3
-      )),
-      processWithRelationAndCoords("US:I",
-        -104.97235, 39.73867, -105.260503, 40.010771,
-        "highway", "trunk_link"
+        "highway", highway
       )
     );
   }

--- a/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
@@ -285,4 +285,148 @@ class RoadsTest extends LayerTest {
       )
     );
   }
+
+  @Test
+  void testRailway() {
+    assertFeatures(12,
+      List.of(Map.of("kind", "rail",
+        "kind_detail", "a",
+        "_minzoom", 11
+      )),
+      processWithRelationAndCoords("",
+        0, 0, 1, 1,
+        "railway", "a"
+      )
+    );
+
+    assertFeatures(12,
+      List.of(Map.of("kind", "rail",
+        "kind_detail", "service",
+        "_minzoom", 13
+      )),
+      processWithRelationAndCoords("",
+        0, 0, 1, 1,
+        "railway", "service"
+      )
+    );
+
+    assertFeatures(12,
+      List.of(Map.of("kind", "rail",
+        "kind_detail", "service",
+        "_minzoom", 14
+      )),
+      processWithRelationAndCoords("",
+        0, 0, 1, 1,
+        "railway", "service",
+        "service", "a"
+      )
+    );
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "funicular",
+    "light_rail",
+    "miniature",
+    "monorail",
+    "narrow_gauge",
+    "preserved",
+    "subway", 
+    "tram"
+  })
+  void testRailwaysSpecial(String railway) {
+    assertFeatures(12,
+      List.of(Map.of("kind", "rail",
+        "kind_detail", railway,
+        "_minzoom", 14
+      )),
+      processWithRelationAndCoords("",
+        0, 0, 1, 1,
+        "railway", railway
+      )
+    );
+  }
+
+  @Test
+  void testRailwayDisused() {
+    assertFeatures(12,
+      List.of(Map.of("kind", "rail",
+        "kind_detail", "disused",
+        "_minzoom", 15
+      )),
+      processWithRelationAndCoords("",
+        0, 0, 1, 1,
+        "railway", "disused"
+      )
+    );
+  }
+
+  @Test
+  void testAerialwayCableCar() {
+    assertFeatures(12,
+      List.of(Map.of("kind", "aerialway",
+        "kind_detail", "cable_car",
+        "_minzoom", 11
+      )),
+      processWithRelationAndCoords("",
+        0, 0, 1, 1,
+        "aerialway", "cable_car"
+      )
+    );
+  }
+
+  @Test
+  void testManMadePier() {
+    assertFeatures(12,
+      List.of(Map.of("kind", "path",
+        "kind_detail", "pier",
+        "_minzoom", 13
+      )),
+      processWithRelationAndCoords("",
+        0, 0, 1, 1,
+        "man_made", "pier"
+      )
+    );
+  }
+
+  @Test
+  void testRouteFerry() {
+    assertFeatures(12,
+      List.of(Map.of("kind", "ferry",
+        "_minzoom", 11
+      )),
+      processWithRelationAndCoords("",
+        0, 0, 1, 1,
+        "route", "ferry"
+      )
+    );
+  }
+
+  @Test
+  void testAerowayTaxiway() {
+    assertFeatures(12,
+      List.of(Map.of("kind", "aeroway",
+        "kind_detail", "taxiway",
+        "_minzoom", 10
+      )),
+      processWithRelationAndCoords("",
+        0, 0, 1, 1,
+        "aeroway", "taxiway"
+      )
+    );
+  }
+
+  @Test
+  void testAerowayRunway() {
+    assertFeatures(12,
+      List.of(Map.of("kind", "aeroway",
+        "kind_detail", "runway",
+        "_minzoom", 9
+      )),
+      processWithRelationAndCoords("",
+        0, 0, 1, 1,
+        "aeroway", "runway"
+      )
+    );
+  }
 }

--- a/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.jupiter.params.provider.CsvSource;
 
 
@@ -331,7 +330,7 @@ class RoadsTest extends LayerTest {
     "monorail",
     "narrow_gauge",
     "preserved",
-    "subway", 
+    "subway",
     "tram"
   })
   void testRailwaysSpecial(String railway) {
@@ -429,4 +428,54 @@ class RoadsTest extends LayerTest {
       )
     );
   }
+
+  @Test
+  void testAvoidBuildings() {
+    assertFeatures(12,
+      List.of(),
+      processWithRelationAndCoords("",
+        0, 0, 1, 1,
+        "aeroway", "runway",
+        "building", "a"
+      )
+    );
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "abandoned",
+    "razed",
+    "demolished",
+    "removed",
+    "construction",
+    "platform",
+    "proposed"
+  })
+  void testRailwayExcluded(String railway) {
+    assertFeatures(12,
+      List.of(),
+      processWithRelationAndCoords("",
+        0, 0, 1, 1,
+        "railway", railway
+      )
+    );
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "yard",
+    "siding",
+    "crossover"
+  })
+  void testRailwayService(String service) {
+    assertFeatures(13,
+      List.of(Map.of("_minzoom", 13)),
+      processWithRelationAndCoords("",
+        0, 0, 1, 1,
+        "railway", "a",
+        "service", service
+      )
+    );
+  }
+
 }

--- a/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
@@ -236,4 +236,53 @@ class RoadsTest extends LayerTest {
       )
     );
   }
+
+  @ParameterizedTest
+  @CsvSource({
+    "pedestrian",
+    "track",
+    "path",
+    "cycleway",
+    "bridleway",
+    "footway",
+    "steps",
+    "corridor"
+  })
+  void testFootways(String highway) {
+    assertFeatures(12,
+      List.of(Map.of("kind_detail", "sidewalk",
+        "_minzoom", 14
+      )),
+      processWithRelationAndCoords("",
+        0, 0, 1, 1,
+        "highway", highway,
+        "footway", "sidewalk"
+      )
+    );
+
+    assertFeatures(12,
+      List.of(Map.of("kind_detail", "crossing",
+        "_minzoom", 14
+      )),
+      processWithRelationAndCoords("",
+        0, 0, 1, 1,
+        "highway", highway,
+        "footway", "crossing"
+      )
+    );
+  }
+
+  @Test
+  void testService() {
+    assertFeatures(12,
+      List.of(Map.of("service", "a",
+        "_minzoom", 14
+      )),
+      processWithRelationAndCoords("",
+        0, 0, 1, 1,
+        "highway", "service",
+        "service", "a"
+      )
+    );
+  }
 }

--- a/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
@@ -29,6 +29,34 @@ class RoadsTest extends LayerTest {
     ));
   }
 
+  private FeatureCollector processWithRelationAndCoords(String network, double startLon, double startLat, double endLon,
+    double endLat, String... arguments) {
+    var relationResult = profile.preprocessOsmRelation(new OsmElement.Relation(1, Map.of(
+      "type", "route",
+      "route", "road",
+      "network", network
+    ), List.of(
+      new OsmElement.Relation.Member(OsmElement.Type.WAY, 2, "role")
+    )));
+
+    Map<String, Object> tags = new HashMap<>();
+    List<String> argumentList = List.of(arguments);
+    if (argumentList.size() % 2 == 0) {
+      for (int i = 0; i < argumentList.size(); i += 2) {
+        tags.put(argumentList.get(i), argumentList.get(i + 1));
+      }
+    }
+
+    return process(SimpleFeature.createFakeOsmFeature(
+      newLineString(startLon, startLat, endLon, endLat),
+      tags,
+      "osm",
+      null,
+      2,
+      relationResult.stream().map(info -> new OsmReader.RelationMember<>("role", info)).toList()
+    ));
+  }
+
   @Test
   void simple() {
     assertFeatures(12,
@@ -48,113 +76,125 @@ class RoadsTest extends LayerTest {
   @Test
   void relation1() {
     // highway=motorway is part of a US Interstate relation and is located in the US -> minzoom should be 3
-    var relationResult = profile.preprocessOsmRelation(new OsmElement.Relation(1, Map.of(
-      "type", "route",
-      "route", "road",
-      "network", "US:I"
-    ), List.of(
-      new OsmElement.Relation.Member(OsmElement.Type.WAY, 2, "role")
-    )));
-
-    FeatureCollector features = process(SimpleFeature.createFakeOsmFeature(
-      newLineString(-104.97235, 39.73867, -105.260503, 40.010771), // Denver - Boulder
-      new HashMap<>(Map.of("highway", "motorway")),
-      "osm",
-      null,
-      2,
-      relationResult.stream().map(info -> new OsmReader.RelationMember<>("role", info)).toList()
-    ));
-
+    // Denver - Boulder
     assertFeatures(0,
       List.of(Map.of(
         "_minzoom", 3
       )),
-      features
+      processWithRelationAndCoords("US:I", -104.97235, 39.73867, -105.260503, 40.010771, "highway", "motorway")
     );
   }
 
   @Test
   void relation2() {
     // highway=motorway is part of US State network and is located in the US -> minzoom should be 6
-    var relationResult = profile.preprocessOsmRelation(new OsmElement.Relation(1, Map.of(
-      "type", "route",
-      "route", "road",
-      "network", "US:US"
-    ), List.of(
-      new OsmElement.Relation.Member(OsmElement.Type.WAY, 2, "role")
-    )));
-
-    FeatureCollector features = process(SimpleFeature.createFakeOsmFeature(
-      newLineString(-104.97235, 39.73867, -105.260503, 40.010771), // Denver - Boulder
-      new HashMap<>(Map.of("highway", "motorway")),
-      "osm",
-      null,
-      2,
-      relationResult.stream().map(info -> new OsmReader.RelationMember<>("role", info)).toList()
-    ));
-
+    // Denver - Boulder
     assertFeatures(0,
       List.of(Map.of(
         "_minzoom", 6
       )),
-      features
+      processWithRelationAndCoords("US:US", -104.97235, 39.73867, -105.260503, 40.010771, "highway", "motorway")
     );
   }
 
   @Test
   void relation3() {
     // highway=motorway is not part of US Interstate/State network and is located in the US -> minzoom should be 7
-    var relationResult = profile.preprocessOsmRelation(new OsmElement.Relation(1, Map.of(
-      "type", "route",
-      "route", "road",
-      "network", "some:network"
-    ), List.of(
-      new OsmElement.Relation.Member(OsmElement.Type.WAY, 2, "role")
-    )));
-
-    FeatureCollector features = process(SimpleFeature.createFakeOsmFeature(
-      newLineString(-104.97235, 39.73867, -105.260503, 40.010771), // Denver - Boulder
-      new HashMap<>(Map.of("highway", "motorway")),
-      "osm",
-      null,
-      2,
-      relationResult.stream().map(info -> new OsmReader.RelationMember<>("role", info)).toList()
-    ));
-
+    // Denver - Boulder
     assertFeatures(0,
       List.of(Map.of(
         "_minzoom", 7
       )),
-      features
+      processWithRelationAndCoords("some:network", -104.97235, 39.73867, -105.260503, 40.010771, "highway", "motorway")
     );
   }
 
   @Test
   void relation4() {
     // highway=motorway is part of US State network and is located ouside of the US -> minzoom should be 3
-    var relationResult = profile.preprocessOsmRelation(new OsmElement.Relation(1, Map.of(
-      "type", "route",
-      "route", "road",
-      "network", "US:US"
-    ), List.of(
-      new OsmElement.Relation.Member(OsmElement.Type.WAY, 2, "role")
-    )));
-
-    FeatureCollector features = process(SimpleFeature.createFakeOsmFeature(
-      newLineString(2.424, 48.832, 8.52332, 47.36919), // Paris - Zurich
-      new HashMap<>(Map.of("highway", "motorway")),
-      "osm",
-      null,
-      2,
-      relationResult.stream().map(info -> new OsmReader.RelationMember<>("role", info)).toList()
-    ));
-
+    // Paris - Zurich
     assertFeatures(0,
       List.of(Map.of(
         "_minzoom", 3
       )),
-      features
+      processWithRelationAndCoords("US:US", 2.424, 48.832, 8.52332, 47.36919, "highway", "motorway")
     );
   }
 
+  @Test
+  void testHighwayExcluded() {
+    assertFeatures(12,
+      List.of(),
+      processWith("highway", "proposed")
+    );
+
+    assertFeatures(12,
+      List.of(),
+      processWith("highway", "abandoned")
+    );
+
+    assertFeatures(12,
+      List.of(),
+      processWith("highway", "razed")
+    );
+
+    assertFeatures(12,
+      List.of(),
+      processWith("highway", "demolished")
+    );
+
+    assertFeatures(12,
+      List.of(),
+      processWith("highway", "removed")
+    );
+
+    assertFeatures(12,
+      List.of(),
+      processWith("highway", "construction")
+    );
+
+    assertFeatures(12,
+      List.of(),
+      processWith("highway", "elevator")
+    );
+  }
+
+  @Test
+  void testHighwayOther() {
+    assertFeatures(12,
+      List.of(Map.of("kind", "other",
+        "kind_detail", "a",
+        "_minzoom", 14
+      )),
+      processWith("highway", "a")
+    );
+
+    assertFeatures(12,
+      List.of(Map.of("kind", "other",
+        "kind_detail", "b",
+        "_minzoom", 14
+      )),
+      processWith("highway", "a",
+        "service", "b")
+    );
+  }
+
+  @Test
+  void testHighwayMotorway() {
+    assertFeatures(12,
+      List.of(Map.of("kind", "highway",
+        "kind_detail", "motorway",
+        "_minzoom", 3
+      )),
+      processWith("highway", "motorway")
+    );
+
+    assertFeatures(12,
+      List.of(Map.of("kind", "highway",
+        "kind_detail", "motorway",
+        "_minzoom", 3
+      )),
+      processWith("highway", "motorway")
+    );
+  }
 }


### PR DESCRIPTION
Adds some unit tests for the roads layer. Not covered is:
* minZoomNames
* minZoomShieldText
* links
* tunnels

With the current test infrastructure I don't know how to easily test attributes that have a min zoom like 

```
.setAttrWithMinzoom("shield_text_length", shieldTextLength, minZoomShieldText)
```

One can supply a zoom to `assertFeatures` but then to check if the min zoom is correct one sort of needs to check the presence at minZoom and the absence at minZoom-1, but I don't know how to test for the absence of an attribute...

Anyway, this increases coverage already quite a bit.
