### PR TITLE
water matcher

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -55,6 +55,7 @@ public class Basemap extends ForwardingProfile {
       var landcover = new Landcover();
       registerHandler(landcover);
       registerSourceHandler("landcover", landcover::processLandcover);
+      registerSourceHandler("ne", landcover::processNe);
     }
 
     if (layer.isEmpty() || layer.equals(Places.LAYER_NAME)) {

--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -84,8 +84,8 @@ public class Basemap extends ForwardingProfile {
     if (layer.isEmpty() || layer.equals(Water.LAYER_NAME)) {
       var water = new Water();
       registerHandler(water);
-      registerSourceHandler("osm", water::processOsm);
-      registerSourceHandler("osm_water", water::processPreparedOsm);
+      // registerSourceHandler("osm", water::processOsm);
+      // registerSourceHandler("osm_water", water::processPreparedOsm);
       registerSourceHandler("ne", water::processNe);
     }
 

--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -84,8 +84,8 @@ public class Basemap extends ForwardingProfile {
     if (layer.isEmpty() || layer.equals(Water.LAYER_NAME)) {
       var water = new Water();
       registerHandler(water);
-      // registerSourceHandler("osm", water::processOsm);
-      // registerSourceHandler("osm_water", water::processPreparedOsm);
+      registerSourceHandler("osm", water::processOsm);
+      registerSourceHandler("osm_water", water::processPreparedOsm);
       registerSourceHandler("ne", water::processNe);
     }
 

--- a/tiles/src/main/java/com/protomaps/basemap/feature/Matcher.java
+++ b/tiles/src/main/java/com/protomaps/basemap/feature/Matcher.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * 
  * <pre>
  * <code>
- *var index = MultiExpression.of(List.of(rule(with("highway", "primary"), use("kind", "major_road")))).index();
+ *var index = MultiExpression.ofOrdered(List.of(rule(with("highway", "primary"), use("kind", "major_road")))).index();
  *var matches = index.getMatches(sourceFeature);
  *String kind = getString(sourceFeature, matches, "kind", "other");
  * </code>
@@ -163,7 +163,7 @@ public class Matcher {
    * 
    * <pre>
    * <code>
-   *var index = MultiExpression.of(List.of(rule(with("highway", "primary", "secondary"), use("kind", fromTag("highway"))))).index();
+   *var index = MultiExpression.ofOrdered(List.of(rule(with("highway", "primary", "secondary"), use("kind", fromTag("highway"))))).index();
    *var matches = index.getMatches(sourceFeature);
    *String kind = getString(sourceFeature, matches, "kind", "other");
    * </code>

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
@@ -41,7 +41,7 @@ public class Earth implements ForwardingProfile.LayerPostProcessor {
     }
     int minZoom = sourceLayer.equals("ne_50m_land") ? 0 : 4;
     int maxZoom = sourceLayer.equals("ne_50m_land") ? 4 : 5;
-    
+
     features.polygon(LAYER_NAME)
       .setAttr("kind", "earth")
       .setZoomRange(minZoom, maxZoom)

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
@@ -39,7 +39,7 @@ public class Earth implements ForwardingProfile.LayerPostProcessor {
     if (!(sourceLayer.equals("ne_50m_land") || sourceLayer.equals("ne_10m_land"))) {
       return;
     }
-    int minZoom = sourceLayer.equals("ne_50m_land") ? 0 : 4;
+    int minZoom = sourceLayer.equals("ne_50m_land") ? 0 : 5;
     int maxZoom = sourceLayer.equals("ne_50m_land") ? 4 : 5;
 
     features.polygon(LAYER_NAME)

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
@@ -15,16 +15,24 @@ public class Earth implements ForwardingProfile.LayerPostProcessor {
 
   public static final String LAYER_NAME = "earth";
 
+  public static final double BUFFER = 0.0625;
+  public static final double MIN_AREA = 10.0;
+
+  public static final double PIXEL_TOLERANCE = 0.2;
+
   @Override
   public String name() {
     return LAYER_NAME;
   }
 
   public void processPreparedOsm(SourceFeature ignoredSf, FeatureCollector features) {
-    features.polygon(this.name())
+    features.polygon(LAYER_NAME)
       .setId(0)
       .setAttr("kind", "earth")
-      .setZoomRange(6, 15).setBufferPixels(8);
+      .setPixelTolerance(PIXEL_TOLERANCE)
+      .setMinPixelSize(1.0)
+      .setMinZoom(6)
+      .setBufferPixels(8);
   }
 
   public void processNe(SourceFeature sf, FeatureCollector features) {
@@ -56,7 +64,7 @@ public class Earth implements ForwardingProfile.LayerPostProcessor {
   public void processOsm(SourceFeature sf, FeatureCollector features) {
     if (sf.canBeLine() && !sf.canBePolygon() && sf.hasTag("natural", "cliff")) {
       int minZoom = 12;
-      var feat = features.line(this.name())
+      var feat = features.line(LAYER_NAME)
         .setId(FeatureId.create(sf))
         .setAttr("min_zoom", minZoom + 1)
         .setAttr("kind", "cliff")
@@ -68,6 +76,6 @@ public class Earth implements ForwardingProfile.LayerPostProcessor {
 
   @Override
   public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) throws GeometryException {
-    return FeatureMerge.mergeOverlappingPolygons(items, 1);
+    return FeatureMerge.mergeNearbyPolygons(items, MIN_AREA, MIN_AREA, 0.5, BUFFER);
   }
 }

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
@@ -10,6 +10,7 @@ import com.protomaps.basemap.feature.FeatureId;
 import com.protomaps.basemap.names.OsmNames;
 import java.util.List;
 
+@SuppressWarnings("java:S1192") // Duplicated string literals
 public class Earth implements ForwardingProfile.LayerPostProcessor {
 
   public static final String LAYER_NAME = "earth";

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
@@ -9,7 +9,6 @@ import com.onthegomap.planetiler.reader.SourceFeature;
 import com.protomaps.basemap.feature.FeatureId;
 import com.protomaps.basemap.names.OsmNames;
 import java.util.List;
-import org.locationtech.jts.geom.Point;
 
 public class Earth implements ForwardingProfile.LayerPostProcessor {
 
@@ -36,29 +35,19 @@ public class Earth implements ForwardingProfile.LayerPostProcessor {
   }
 
   public void processNe(SourceFeature sf, FeatureCollector features) {
-    var sourceLayer = sf.getSourceLayer();
-    if (sourceLayer.equals("ne_50m_land")) {
-      features.polygon(this.name()).setZoomRange(0, 4).setBufferPixels(8).setAttr("kind", "earth");
-    } else if (sourceLayer.equals("ne_10m_land")) {
-      features.polygon(this.name()).setZoomRange(5, 5).setBufferPixels(8).setAttr("kind", "earth");
+    String sourceLayer = sf.getSourceLayer();
+    if (!(sourceLayer.equals("ne_50m_land") || sourceLayer.equals("ne_10m_land"))) {
+      return;
     }
-    // Daylight landcover uses ESA WorldCover which only goes to a latitude of roughly 80 deg S.
-    // Parts of Antarctica therefore get no landcover = glacier from Daylight.
-    // To fix this, we add glaciated areas from Natural Earth in Antarctica.
-    if (sourceLayer.equals("ne_10m_glaciated_areas")) {
-      try {
-        Point centroid = (Point) sf.centroid();
-        // Web Mercator Y = 0.7 is roughly 60 deg South, i.e., Antarctica.
-        if (centroid.getY() > 0.7) {
-          features.polygon("landcover")
-            .setAttr("kind", "glacier")
-            .setZoomRange(0, 7)
-            .setMinPixelSize(0.0);
-        }
-      } catch (GeometryException e) {
-        System.out.println("Error: " + e);
-      }
-    }
+    int minZoom = sourceLayer.equals("ne_50m_land") ? 0 : 4;
+    int maxZoom = sourceLayer.equals("ne_50m_land") ? 4 : 5;
+    
+    features.polygon(LAYER_NAME)
+      .setAttr("kind", "earth")
+      .setZoomRange(minZoom, maxZoom)
+      .setPixelTolerance(PIXEL_TOLERANCE)
+      .setMinPixelSize(1.0)
+      .setBufferPixels(8);
   }
 
   public void processOsm(SourceFeature sf, FeatureCollector features) {
@@ -68,7 +57,8 @@ public class Earth implements ForwardingProfile.LayerPostProcessor {
         .setId(FeatureId.create(sf))
         .setAttr("min_zoom", minZoom + 1)
         .setAttr("kind", "cliff")
-        .setZoomRange(minZoom, 15);
+        .setPixelTolerance(PIXEL_TOLERANCE)
+        .setMinZoom(minZoom);
 
       OsmNames.setOsmNames(feat, sf, 0);
     }

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
@@ -1,6 +1,7 @@
 package com.protomaps.basemap.layers;
 
 import com.onthegomap.planetiler.FeatureCollector;
+import com.onthegomap.planetiler.FeatureMerge;
 import com.onthegomap.planetiler.ForwardingProfile;
 import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.geo.GeometryException;
@@ -8,6 +9,8 @@ import com.onthegomap.planetiler.reader.SourceFeature;
 import com.protomaps.basemap.feature.FeatureId;
 import java.util.List;
 import java.util.Map;
+
+import org.locationtech.jts.geom.Point;
 
 public class Landcover implements ForwardingProfile.LayerPostProcessor {
 
@@ -17,6 +20,28 @@ public class Landcover implements ForwardingProfile.LayerPostProcessor {
   static final Map<String, Integer> sortKeyMapping =
     Map.of("barren", 0, "snow", 1, "crop", 2, "shrub", 3, "grass", 4, "trees", 5);
 
+  public void processNe(SourceFeature sf, FeatureCollector features) {   
+    // Daylight landcover uses ESA WorldCover which only goes to a latitude of roughly 80 deg S.
+    // Parts of Antarctica therefore get no landcover = glacier from Daylight.
+    // To fix this, we add glaciated areas from Natural Earth in Antarctica.
+    if (sf.getSourceLayer().equals("ne_10m_glaciated_areas")) {
+      try {
+        Point centroid = (Point) sf.centroid();
+        // Web Mercator Y = 0.7 is roughly 60 deg South, i.e., Antarctica.
+        if (centroid.getY() > 0.7) {
+          features.polygon(LAYER_NAME)
+            .setId(0)
+            .setAttr("kind", "glacier")
+            .setMaxZoom(7)
+            .setMinPixelSize(1.0)
+            .setPixelTolerance(Earth.PIXEL_TOLERANCE);
+        }
+      } catch (GeometryException e) {
+        System.out.println("Error: " + e);
+      }
+    }
+  }
+
   public void processLandcover(SourceFeature sf, FeatureCollector features) {
     String daylightClass = sf.getString("class");
     String kind = kindMapping.getOrDefault(daylightClass, daylightClass);
@@ -24,12 +49,13 @@ public class Landcover implements ForwardingProfile.LayerPostProcessor {
     // polygons are disjoint and non-overlapping, but order them in archive in consistent way
     Integer sortKey = sortKeyMapping.getOrDefault(daylightClass, 6);
 
-    features.polygon(this.name())
-      .setId(FeatureId.create(sf))
+    features.polygon(LAYER_NAME)
+      .setId(0)
       .setAttr("kind", kind)
       .setZoomRange(0, 7)
       .setSortKey(sortKey)
-      .setMinPixelSize(0.0);
+      .setMinPixelSize(1.0)
+      .setPixelTolerance(Earth.PIXEL_TOLERANCE);
   }
 
   public static final String LAYER_NAME = "landcover";
@@ -41,6 +67,6 @@ public class Landcover implements ForwardingProfile.LayerPostProcessor {
 
   @Override
   public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) throws GeometryException {
-    return items;
+    return FeatureMerge.mergeNearbyPolygons(items, 1.0, 1.0, 0.5, Earth.BUFFER);
   }
 }

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
@@ -35,7 +35,7 @@ public class Landcover implements ForwardingProfile.LayerPostProcessor {
             .setPixelTolerance(Earth.PIXEL_TOLERANCE);
         }
       } catch (GeometryException e) {
-        System.out.println("Error: " + e);
+        e.log("Error: " + e);
       }
     }
   }

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
@@ -6,10 +6,8 @@ import com.onthegomap.planetiler.ForwardingProfile;
 import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.reader.SourceFeature;
-import com.protomaps.basemap.feature.FeatureId;
 import java.util.List;
 import java.util.Map;
-
 import org.locationtech.jts.geom.Point;
 
 public class Landcover implements ForwardingProfile.LayerPostProcessor {
@@ -20,7 +18,7 @@ public class Landcover implements ForwardingProfile.LayerPostProcessor {
   static final Map<String, Integer> sortKeyMapping =
     Map.of("barren", 0, "snow", 1, "crop", 2, "shrub", 3, "grass", 4, "trees", 5);
 
-  public void processNe(SourceFeature sf, FeatureCollector features) {   
+  public void processNe(SourceFeature sf, FeatureCollector features) {
     // Daylight landcover uses ESA WorldCover which only goes to a latitude of roughly 80 deg S.
     // Parts of Antarctica therefore get no landcover = glacier from Daylight.
     // To fix this, we add glaciated areas from Natural Earth in Antarctica.

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import org.locationtech.jts.geom.Point;
 
+@SuppressWarnings("java:S1192") // Duplicated string literals
 public class Landcover implements ForwardingProfile.LayerPostProcessor {
 
   static final Map<String, String> kindMapping = Map.of("urban", "urban_area", "crop", "farmland", "grass", "grassland",

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
@@ -61,7 +61,7 @@ public class Landuse implements ForwardingProfile.LayerPostProcessor {
       Wildlife Sanctuary
     """;
 
-  private static final MultiExpression.Index<Map<String, Object>> index = MultiExpression.of(List.of(
+  private static final MultiExpression.Index<Map<String, Object>> index = MultiExpression.ofOrdered(List.of(
     rule(
       with("""
           aeroway

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -178,13 +178,13 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
       with("name"),
       with("place", "sea"),
       use("kind", "sea"),
-      use("minZoom", 3)
+      use("minZoom", 6)
     ),
     rule(
       with("name"),
       with("place", "ocean"),
       use("kind", "ocean"),
-      use("minZoom", 0)
+      use("minZoom", 6)
     )
   )).index();
 
@@ -308,7 +308,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
       var feat = features.point(LAYER_NAME)
         .setId(FeatureId.create(sf))
         .setAttr("kind", kind)
-        .setAttr("min_zoom", minZoom + 1)
+        .setAttr("min_zoom", minZoom)
         .setSortKey(minZoom)
         .setZoomRange(minZoom, 15);
 

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -23,6 +23,7 @@ import com.protomaps.basemap.names.OsmNames;
 import java.util.List;
 import java.util.Map;
 
+@SuppressWarnings("java:S1192") // Duplicated string literals
 public class Water implements ForwardingProfile.LayerPostProcessor {
 
   private static final double WORLD_AREA_FOR_70K_SQUARE_METERS =

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -23,7 +23,6 @@ import com.protomaps.basemap.names.NeNames;
 import com.protomaps.basemap.names.OsmNames;
 import java.util.List;
 import java.util.Map;
-import java.util.ArrayList;
 
 public class Water implements ForwardingProfile.LayerPostProcessor {
 

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -84,22 +84,24 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
       return;
     }
 
-    Integer minZoom = getInteger(sf, matches, "minZoom", null);
+    String minZoomString = getString(sf, matches, "minZoom", null);
     
-    if (minZoom != null) {
-      var themeMinZoom = sf.getSourceLayer().contains("_50m_") ? 0 : 5;
-      var themeMaxZoom = sf.getSourceLayer().contains("_50m_") ? 4 : 5;
+    if (minZoomString != null) {
+      int minZoom = (int) Math.round(Double.parseDouble(minZoomString));
+
+      int themeMinZoom = sf.getSourceLayer().contains("_50m_") ? 0 : 5;
+      int themeMaxZoom = sf.getSourceLayer().contains("_50m_") ? 4 : 5;
 
       features.polygon(LAYER_NAME)
         .setAttr("kind", kind)
         .setAttr("sort_rank", 200)
-        .setZoomRange(0, themeMaxZoom)
+        .setZoomRange(Math.max(themeMinZoom, minZoom), themeMaxZoom)
         // (nvkelso 20230802) Don't set setMinPixelSize here else small islands chains like Hawaii are garbled
         .setBufferPixels(8);
     }
 
     if (sf.getSourceLayer().equals("ne_10m_lakes") && sf.hasTag("min_label") && sf.hasTag("name")) {
-      minZoom = (int) sf.getLong("min_label");
+      int minZoom = (int) Math.round(Double.parseDouble(sf.getString("min_label")));
       var waterLabelPosition = features.pointOnSurface(this.name())
         .setAttr("kind", kind)
         .setAttr("min_zoom", minZoom + 1)

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -202,6 +202,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
       .setId(0)
       .setAttr("kind", "ocean")
       .setAttr("sort_rank", 200)
+      // .setPixelTolerance(0.2)
       .setZoomRange(6, 15).setBufferPixels(8);
   }
 
@@ -228,6 +229,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
       features.polygon(LAYER_NAME)
         .setAttr("kind", kind)
         .setAttr("sort_rank", 200)
+        // .setPixelTolerance(0.2)
         .setZoomRange(Math.max(themeMinZoom, minZoom), themeMaxZoom)
         // (nvkelso 20230802) Don't set setMinPixelSize here else small islands chains like Hawaii are garbled
         .setBufferPixels(8);
@@ -272,6 +274,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
         .setAttrWithMinzoom("bridge", sf.getString("bridge"), 12)
         .setAttrWithMinzoom("tunnel", sf.getString("tunnel"), 12)
         .setAttrWithMinzoom("layer", Parse.parseIntOrNull(sf.getString("layer")), 12)
+        // .setPixelTolerance(0.2)
         .setZoomRange(6, 15)
         .setMinPixelSize(1.0)
         .setBufferPixels(8);
@@ -378,11 +381,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
 
   @Override
   public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) throws GeometryException {
-    items = FeatureMerge.mergeLineStrings(items,
-      0.5, // after merging, remove lines that are still less than 0.5px long
-      0.1, // simplify output linestrings using a 0.1px tolerance
-      4 // remove any detail more than 4px outside the tile boundary
-    );
+    items = FeatureMerge.mergeLineStrings(items, 0.5, 0.2, 4.0);
     return FeatureMerge.mergeOverlappingPolygons(items, 1);
   }
 }

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -59,6 +59,136 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
     )
   )).index();
 
+  private static final MultiExpression.Index<Map<String, Object>> osmIndex = MultiExpression.of(List.of(
+    rule(
+      with("natural", "reef"),
+      use("kind", "reef")
+    ),
+    rule(
+      with("natural", "reef"),
+      with("""
+        reef
+        coral
+        rock
+        sand
+      """),
+      use("kindDetail", fromTag("reef"))
+    ),
+    rule(
+      with("waterway", "drain"),
+      use("kind", "drain"),
+      use("minZoom", 16)
+    ),
+    rule(
+      with("waterway", "ditch"),
+      use("kind", "ditch"),
+      use("minZoom", 16)
+    ),
+    rule(
+      with("waterway", "stream"),
+      use("kind", "stream"),
+      use("minZoom", 11)
+    ),
+    rule(
+      with("waterway", "river"),
+      use("kind", "river"),
+      use("minZoom", 9)
+    ),
+    rule(
+      with("waterway", "canal"),
+      use("kind", "canal"),
+      use("minZoom", 11)
+    ),
+    rule(
+      with("waterway", "canal"),
+      with("boat", "yes"),
+      use("kind", "canal"),
+      use("minZoom", 9)
+    ),
+    rule(
+      with("amenity", "swimming_pool"),
+      use("kind", "swimming_pool")
+    ),
+    rule(
+      with("leisure", "swimming_pool"),
+      use("kind", "swimming_pool")
+    ),
+    rule(
+      with("landuse", "reservoir"),
+      use("kind", "lake")
+    ),
+    rule(
+      with("landuse", "basin"),
+      use("kind", "basin")
+    ),
+    rule(
+      with("""
+        natural
+        fjord
+        strait
+        bay
+      """),
+      use("kind", fromTag("natural"))
+    ),
+    rule(
+      with("natural", "water"),
+      use("kind", "water")
+    ),
+    rule(
+      with("natural", "water"),
+      with("""
+        water
+        basin
+        canal
+        ditch
+        drain
+        lake
+        river
+        stream
+      """),
+      use("kindDetail", fromTag("water"))
+    ),
+    rule(
+      with("natural", "water"),
+      with("""
+        water
+        lagoon
+        oxbow
+        pond
+        reservoir
+        wastewater
+      """),
+      use("kindDetail", "lake")
+    ),
+    rule(
+      with("amenity", "fountain"),
+      use("kind", "fountain")
+    ),
+    rule(
+      with("waterway", "dock"),
+      use("kind", "dock")
+    ),
+    rule(
+      with("waterway", "riverbank"),
+      use("kind", "riverbank")
+    ),
+    rule(
+      with("covered", "yes"),
+      use("kind", null)
+    ),
+    rule(
+      with("name"),
+      with("place", "sea"),
+      use("kind", "sea")
+    ),
+    rule(
+      with("name"),
+      with("place", "ocean"),
+      use("kind", "ocean")
+    )
+  )).index();
+
+
   @Override
   public String name() {
     return LAYER_NAME;

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -388,7 +388,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
 
     // points
     if (sf.isPoint()) {
-      int minZoom = getInteger(sf, matches, "minZoom", 12);
+      int minZoom = getInteger(sf, matches, "minZoom", 15);
       var feat = features.point(LAYER_NAME)
         .setId(FeatureId.create(sf))
         .setAttr("kind", kind)

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -1,6 +1,7 @@
 package com.protomaps.basemap.layers;
 
 import static com.protomaps.basemap.feature.Matcher.fromTag;
+import static com.protomaps.basemap.feature.Matcher.getBoolean;
 import static com.protomaps.basemap.feature.Matcher.getInteger;
 import static com.protomaps.basemap.feature.Matcher.getString;
 import static com.protomaps.basemap.feature.Matcher.rule;
@@ -126,7 +127,8 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
           strait
           bay
         """),
-      use("kind", fromTag("natural"))
+      use("kind", fromTag("natural")),
+      use("keepPolygon", false)
     ),
     rule(
       with("natural", "water"),
@@ -178,12 +180,14 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
       with("name"),
       with("place", "sea"),
       use("kind", "sea"),
+      use("keepPolygon", false),
       use("minZoom", 6)
     ),
     rule(
       with("name"),
       with("place", "ocean"),
       use("kind", "ocean"),
+      use("keepPolygon", false),
       use("minZoom", 6)
     )
   )).index();
@@ -255,9 +259,10 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
     }
 
     String kindDetail = getString(sf, matches, "kindDetail", null);
+    boolean keepPolygon = getBoolean(sf, matches, "keepPolygon", true);
 
     // polygons
-    if (sf.canBePolygon()) {
+    if (sf.canBePolygon() && keepPolygon) {
       features.polygon(LAYER_NAME)
         .setAttr("kind", kind)
         .setAttr("kind_detail", kindDetail)

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -221,9 +221,10 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
     ),
     rule(
       with("place", "sea"),
-      with("_can_be_polygon"),
       with("""
           name:en
+          North Sea
+          Baltic Sea
           Black Sea
           Caspian Sea
       """),

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -411,7 +411,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
       }
 
       for (int i = 6; i < 15; ++i) {
-        if (wayArea > Math.pow(4, 15 - i)) {
+        if (wayArea > Math.pow(4.0, 15.0 - i)) {
           nameMinZoom = i;
           break;
         }

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -19,7 +19,6 @@ import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.reader.SourceFeature;
 import com.onthegomap.planetiler.util.Parse;
 import com.protomaps.basemap.feature.FeatureId;
-import com.protomaps.basemap.names.NeNames;
 import com.protomaps.basemap.names.OsmNames;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +30,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
 
   public static final String LAYER_NAME = "water";
 
-  private static final MultiExpression.Index<Map<String, Object>> neIndex = MultiExpression.of(List.of(
+  private static final MultiExpression.Index<Map<String, Object>> neIndex = MultiExpression.ofOrdered(List.of(
     rule(
       with("featurecla", "Ocean"),
       use("minZoom", fromTag("min_zoom")),
@@ -69,7 +68,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
     )
   )).index();
 
-  private static final MultiExpression.Index<Map<String, Object>> osmIndex = MultiExpression.of(List.of(
+  private static final MultiExpression.Index<Map<String, Object>> osmIndex = MultiExpression.ofOrdered(List.of(
     rule(
       with("natural", "reef"),
       use("kind", "reef")
@@ -197,37 +196,47 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
       with("place", "sea"),
       with("_can_be_polygon"),
       with("""
-        name:en
-        Caspian Sea
-        Red Sea
-        Persian Gulf
-        Sea of Oman
-        Gulf of Aden
-        Gulf of Thailand
-        Sea of Japan
-      """),
+          name:en
+          North Sea
+          Alboran Sea
+        """),
+      use("kind", null)
+    ),
+    rule(
+      with("place", "sea"),
+      with("_can_be_polygon"),
+      with("""
+          name:en
+          Caspian Sea
+          Red Sea
+          Persian Gulf
+          Sea of Oman
+          Gulf of Aden
+          Gulf of Thailand
+          Sea of Japan
+        """),
       use("minZoom", 5)
     ),
     rule(
       with("place", "sea"),
       with("_can_be_polygon"),
       with("""
-        name:en
-        Arabian Sea
-        Bay of Bengal
-        Black Sea
-      """),
+          name:en
+          Arabian Sea
+          Bay of Bengal
+          Black Sea
+        """),
       use("minZoom", 3)
     ),
     rule(
       with("place", "sea"),
       with("""
-          name:en
-          North Sea
-          Baltic Sea
-          Black Sea
-          Caspian Sea
-      """),
+            name:en
+            North Sea
+            Baltic Sea
+            Black Sea
+            Caspian Sea
+        """),
       use("nameOverride", fromTag("name:en"))
     ),
     rule(
@@ -240,27 +249,26 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
       with("place", "sea"),
       with("_is_point"),
       with("""
-        name:en
-        North Atlantic Ocean
-        South Atlantic Ocean
-        Caribbean Sea
-        Gulf of Mexico
-        Mediterranean Sea
-        North Sea
-        Philippine Sea
-        Tasman Sea
-        Fiji Sea
-        South China Sea
-        North Pacific Ocean
-        South Pacific Ocean
-        Scotia Sea
-        Weddell Sea
-        Indian Ocean
-        Bering Sea
-        Gulf of Alaska
-        Gulf of Guinea
-      """),
-      use("kind", "sea"),
+          name:en
+          North Atlantic Ocean
+          South Atlantic Ocean
+          Caribbean Sea
+          Gulf of Mexico
+          Mediterranean Sea
+          North Sea
+          Philippine Sea
+          Tasman Sea
+          Fiji Sea
+          South China Sea
+          North Pacific Ocean
+          South Pacific Ocean
+          Scotia Sea
+          Weddell Sea
+          Indian Ocean
+          Bering Sea
+          Gulf of Alaska
+          Gulf of Guinea
+        """),
       use("minZoom", 3)
     ),
     rule(
@@ -339,7 +347,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
     if (nameOverride != null) {
       sf.setTag("name", nameOverride);
     }
-    
+
     String kindDetail = getString(sf, matches, "kindDetail", null);
     boolean keepPolygon = getBoolean(sf, matches, "keepPolygon", true);
 
@@ -381,7 +389,6 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
     // points
     if (sf.isPoint()) {
       int minZoom = getInteger(sf, matches, "minZoom", 12);
-
       var feat = features.point(LAYER_NAME)
         .setId(FeatureId.create(sf))
         .setAttr("kind", kind)

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -65,7 +65,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
   }
 
   public void processPreparedOsm(SourceFeature ignoredSf, FeatureCollector features) {
-    features.polygon(this.name())
+    features.polygon(LAYER_NAME)
       .setId(0)
       .setAttr("kind", "ocean")
       .setAttr("sort_rank", 200)
@@ -86,7 +86,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
 
     String minZoomString = getString(sf, matches, "minZoom", null);
     
-    if (minZoomString != null) {
+    if (sf.canBePolygon() && minZoomString != null) {
       int minZoom = (int) Math.round(Double.parseDouble(minZoomString));
 
       int themeMinZoom = sf.getSourceLayer().contains("_50m_") ? 0 : 5;
@@ -102,7 +102,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
 
     if (sf.getSourceLayer().equals("ne_10m_lakes") && sf.hasTag("min_label") && sf.hasTag("name")) {
       int minZoom = (int) Math.round(Double.parseDouble(sf.getString("min_label")));
-      var waterLabelPosition = features.pointOnSurface(this.name())
+      var waterLabelPosition = features.pointOnSurface(LAYER_NAME)
         .setAttr("kind", kind)
         .setAttr("min_zoom", minZoom + 1)
         .setZoomRange(minZoom + 1, 5)
@@ -167,7 +167,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
         kind = "swimming_pool";
       }
 
-      var feature = features.polygon(this.name())
+      var feature = features.polygon(LAYER_NAME)
         // Core Tilezen schema properties
         .setAttr("kind", kind)
         .setAttr("sort_rank", 200)
@@ -209,7 +209,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
         }
       }
 
-      var feat = features.line(this.name())
+      var feat = features.line(LAYER_NAME)
         .setId(FeatureId.create(sf))
         .setAttr("kind", kind)
         // Used for client-side label collisions
@@ -258,7 +258,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
         minZoom = 3;
       }
 
-      var feat = features.point(this.name())
+      var feat = features.point(LAYER_NAME)
         .setId(FeatureId.create(sf))
         .setAttr("kind", kind)
         // Used for client-side label collisions
@@ -350,7 +350,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
         nameMinZoom = 14;
       }
 
-      var waterLabelPosition = features.pointOnSurface(this.name())
+      var waterLabelPosition = features.pointOnSurface(LAYER_NAME)
         // Core Tilezen schema properties
         .setAttr("kind", kind)
         .setAttr("kind_detail", kindDetail)

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -188,20 +188,45 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
       use("kind", null)
     ),
     rule(
-      with("name"),
       with("place", "sea"),
       use("kind", "sea"),
       use("keepPolygon", false),
       use("minZoom", 6)
     ),
     rule(
-      with("name"),
+      with("place", "sea"),
+      with("""
+        name:en
+        North Atlantic Ocean
+        South Atlantic Ocean
+        Caribbean Sea
+        Gulf of Mexico
+        Mediterranean Sea
+        North Sea
+        Philippine Sea
+        Tasman Sea
+        Fiji Sea
+        South China Sea
+        North Pacific Ocean
+        South Pacific Ocean
+        Scotia Sea
+        Weddell Sea
+        Indian Ocean
+        Bering Sea
+        Gulf of Alaska
+        Gulf of Guinea
+      """),
+      use("minZoom", 3)
+    ),
+    rule(
       with("place", "ocean"),
       use("kind", "ocean"),
       use("keepPolygon", false),
-      use("minZoom", 6)
+      use("minZoom", 0)
     )
   )).index();
+
+
 
   @Override
   public String name() {
@@ -333,7 +358,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
         .setAttr("kind", kind)
         .setAttr("min_zoom", minZoom)
         .setSortKey(minZoom)
-        .setZoomRange(minZoom, 15);
+        .setMinZoom(minZoom);
 
       OsmNames.setOsmNames(feat, sf, 0);
     }

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -288,6 +288,8 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
         .setAttrWithMinzoom("layer", Parse.parseIntOrNull(sf.getString("layer")), 12)
         .setAttr("sort_rank", 200)
         .setSortKey(minZoom)
+        .setMinPixelSize(0)
+        .setPixelTolerance(0)
         .setZoomRange(minZoom, 15);
 
       // Set "brunnel" (bridge / tunnel) property where "level" = 1 is a bridge, 0 is ground level, and -1 is a tunnel
@@ -376,6 +378,11 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
 
   @Override
   public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) throws GeometryException {
+    items = FeatureMerge.mergeLineStrings(items,
+      0.5, // after merging, remove lines that are still less than 0.5px long
+      0.1, // simplify output linestrings using a 0.1px tolerance
+      4 // remove any detail more than 4px outside the tile boundary
+    );
     return FeatureMerge.mergeOverlappingPolygons(items, 1);
   }
 }

--- a/tiles/src/test/java/com/protomaps/basemap/feature/MatcherTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/feature/MatcherTest.java
@@ -83,7 +83,7 @@ class MatcherTest {
 
   @Test
   void testGetStringWith() {
-    var index = MultiExpression.of(List.of(
+    var index = MultiExpression.ofOrdered(List.of(
       rule(
         with(),
         use("a", "b")
@@ -106,7 +106,7 @@ class MatcherTest {
 
   @Test
   void testGetStringWithA() {
-    var index = MultiExpression.of(List.of(
+    var index = MultiExpression.ofOrdered(List.of(
       rule(
         with("a"),
         use("b", "c")
@@ -136,7 +136,7 @@ class MatcherTest {
 
   @Test
   void testGetStringWithAB() {
-    var index = MultiExpression.of(List.of(
+    var index = MultiExpression.ofOrdered(List.of(
       rule(
         with("a", "b"),
         use("c", "d")
@@ -166,7 +166,7 @@ class MatcherTest {
 
   @Test
   void testGetStringWithoutAB() {
-    var index = MultiExpression.of(List.of(
+    var index = MultiExpression.ofOrdered(List.of(
       rule(
         without("a", "b"),
         use("c", "d")
@@ -196,7 +196,7 @@ class MatcherTest {
 
   @Test
   void testGetStringWithABC() {
-    var index = MultiExpression.of(List.of(
+    var index = MultiExpression.ofOrdered(List.of(
       rule(
         with("a", "b", "c"),
         use("d", "e")
@@ -236,7 +236,7 @@ class MatcherTest {
 
   @Test
   void testGetStringMultipleUse() {
-    var index = MultiExpression.of(List.of(
+    var index = MultiExpression.ofOrdered(List.of(
       rule(
         with(),
         use("a", "b"),
@@ -258,7 +258,7 @@ class MatcherTest {
 
   @Test
   void testGetStringLastRule() {
-    var index = MultiExpression.of(List.of(
+    var index = MultiExpression.ofOrdered(List.of(
       rule(
         with(),
         use("a", "b")
@@ -282,7 +282,7 @@ class MatcherTest {
 
   @Test
   void testGetStringTypeMismatch() {
-    var index = MultiExpression.of(List.of(
+    var index = MultiExpression.ofOrdered(List.of(
       rule(
         with(),
         use("a", 1)
@@ -302,7 +302,7 @@ class MatcherTest {
 
   @Test
   void testGetStringFromTag() {
-    var index = MultiExpression.of(List.of(
+    var index = MultiExpression.ofOrdered(List.of(
       rule(
         with(),
         use("a", fromTag("b"))
@@ -332,7 +332,7 @@ class MatcherTest {
 
   @Test
   void testGetInteger() {
-    var index = MultiExpression.of(List.of(
+    var index = MultiExpression.ofOrdered(List.of(
       rule(
         with(),
         use("a", 1)
@@ -352,7 +352,7 @@ class MatcherTest {
 
   @Test
   void testGetIntegerFromTag() {
-    var index = MultiExpression.of(List.of(
+    var index = MultiExpression.ofOrdered(List.of(
       rule(
         with(),
         use("a", fromTag("b"))
@@ -392,7 +392,7 @@ class MatcherTest {
 
   @Test
   void testGetDouble() {
-    var index = MultiExpression.of(List.of(
+    var index = MultiExpression.ofOrdered(List.of(
       rule(
         with(),
         use("a", 1.5)
@@ -412,7 +412,7 @@ class MatcherTest {
 
   @Test
   void testGetDoubleFromTag() {
-    var index = MultiExpression.of(List.of(
+    var index = MultiExpression.ofOrdered(List.of(
       rule(
         with(),
         use("a", fromTag("b"))
@@ -452,7 +452,7 @@ class MatcherTest {
 
   @Test
   void testGetBoolean() {
-    var index = MultiExpression.of(List.of(
+    var index = MultiExpression.ofOrdered(List.of(
       rule(
         with(),
         use("a", true)
@@ -472,7 +472,7 @@ class MatcherTest {
 
   @Test
   void testGetBooleanFromTag() {
-    var index = MultiExpression.of(List.of(
+    var index = MultiExpression.ofOrdered(List.of(
       rule(
         with(),
         use("a", fromTag("b"))

--- a/tiles/src/test/java/com/protomaps/basemap/layers/EarthTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/EarthTest.java
@@ -36,4 +36,32 @@ class EarthTest extends LayerTest {
         0
       )));
   }
+
+  @Test
+  void testNe() {
+    assertFeatures(15,
+      List.of(Map.of("kind", "earth",
+        "_minzoom", 0,
+        "_maxzoom", 4)),
+      process(SimpleFeature.create(
+        newPolygon(0, 0, 0, 1, 1, 1, 0, 0),
+        new HashMap<>(Map.of()),
+        "ne",
+        "ne_50m_land",
+        1
+      ))
+    );
+    assertFeatures(15,
+      List.of(Map.of("kind", "earth",
+        "_minzoom", 5,
+        "_maxzoom", 5)),
+      process(SimpleFeature.create(
+        newPolygon(0, 0, 0, 1, 1, 1, 0, 0),
+        new HashMap<>(Map.of()),
+        "ne",
+        "ne_10m_land",
+        1
+      ))
+    );
+  }
 }

--- a/tiles/src/test/java/com/protomaps/basemap/layers/LandcoverTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/LandcoverTest.java
@@ -6,6 +6,7 @@ import com.onthegomap.planetiler.reader.SimpleFeature;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -31,5 +32,32 @@ class LandcoverTest extends LayerTest {
         null,
         0
       )));
+  }
+
+  @Test
+  void testNe() {
+    assertFeatures(15,
+      List.of(),
+      process(SimpleFeature.create(
+        newPolygon(0, 0, 0, 1, 1, 1, 0, 0),
+        new HashMap<>(Map.of()),
+        "ne",
+        "ne_10m_glaciated_areas",
+        1
+      ))
+    );
+
+    assertFeatures(15,
+      List.of(Map.of("kind", "glacier",
+        "_minzoom", 0,
+        "_maxzoom", 7)),
+      process(SimpleFeature.create(
+        newPolygon(0, -75, 0, -76, 1, -76, 0, -75),
+        new HashMap<>(Map.of()),
+        "ne",
+        "ne_10m_glaciated_areas",
+        1
+      ))
+    );
   }
 }

--- a/tiles/src/test/java/com/protomaps/basemap/layers/WaterTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/WaterTest.java
@@ -41,7 +41,7 @@ class WaterTest extends LayerTest {
       List.of(Map.of("kind", "fountain")),
       process(SimpleFeature.create(
         newPolygon(0, 0, 0, 1, 1, 1, 0, 0),
-        new HashMap<>(Map.of("natural", "water", "amenity", "fountain")),
+        new HashMap<>(Map.of("amenity", "fountain")),
         "osm",
         null,
         0

--- a/tiles/src/test/java/com/protomaps/basemap/layers/WaterTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/WaterTest.java
@@ -84,7 +84,9 @@ class WaterTest extends LayerTest {
       List.of(Map.of("kind", "ocean")),
       process(SimpleFeature.create(
         newPoint(1, 1),
-        new HashMap<>(Map.of("place", "ocean")),
+        new HashMap<>(Map.of("place", "ocean",
+          "name", "a"
+        )),
         "osm",
         null,
         0


### PR DESCRIPTION
Copied filter rules from tilezen's water.yaml file. Each copied filter rule was marked with "done". Each skipped item was marked with "skip" in https://github.com/wipfli/vector-datasource/pull/1

Skipped are the following

- NE coast lines
- intermittent
- boat
- reservoir
- alkaline

Rules in tilezen were evaluated top to bottom, we do pick the last. So I reversed the order of the filter rules, e.g., covered=yes appears last here, in tilezen it was first...
