### PR TITLE
use vector tile id=1 since 0 is special cased.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Tiles 4.7.1
+------
+- adjust vector tile feature IDs to start at id=1 [#420]
+
 Tiles 4.7.0
 ------
 - port water, earth and landcover to use Matchers [#416]

--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -116,7 +116,7 @@ public class Basemap extends ForwardingProfile {
 
   @Override
   public String version() {
-    return "4.7.0";
+    return "4.7.1";
   }
 
   @Override

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
@@ -27,7 +27,7 @@ public class Earth implements ForwardingProfile.LayerPostProcessor {
 
   public void processPreparedOsm(SourceFeature ignoredSf, FeatureCollector features) {
     features.polygon(LAYER_NAME)
-      .setId(0)
+      .setId(1)
       .setAttr("kind", "earth")
       .setPixelTolerance(PIXEL_TOLERANCE)
       .setMinPixelSize(1.0)
@@ -44,6 +44,7 @@ public class Earth implements ForwardingProfile.LayerPostProcessor {
     int maxZoom = sourceLayer.equals("ne_50m_land") ? 4 : 5;
 
     features.polygon(LAYER_NAME)
+      .setId(1)
       .setAttr("kind", "earth")
       .setZoomRange(minZoom, maxZoom)
       .setPixelTolerance(PIXEL_TOLERANCE)

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
@@ -29,7 +29,7 @@ public class Landcover implements ForwardingProfile.LayerPostProcessor {
         // Web Mercator Y = 0.7 is roughly 60 deg South, i.e., Antarctica.
         if (centroid.getY() > 0.7) {
           features.polygon(LAYER_NAME)
-            .setId(0)
+            .setId(1)
             .setAttr("kind", "glacier")
             .setMaxZoom(7)
             .setMinPixelSize(1.0)
@@ -49,7 +49,7 @@ public class Landcover implements ForwardingProfile.LayerPostProcessor {
     Integer sortKey = sortKeyMapping.getOrDefault(daylightClass, 6);
 
     features.polygon(LAYER_NAME)
-      .setId(0)
+      .setId(1 + sortKey)
       .setAttr("kind", kind)
       .setZoomRange(0, 7)
       .setSortKey(sortKey)

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
@@ -49,7 +49,7 @@ public class Landcover implements ForwardingProfile.LayerPostProcessor {
     Integer sortKey = sortKeyMapping.getOrDefault(daylightClass, 6);
 
     features.polygon(LAYER_NAME)
-      .setId(1 + sortKey)
+      .setId(1L + sortKey)
       .setAttr("kind", kind)
       .setZoomRange(0, 7)
       .setSortKey(sortKey)

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -286,7 +286,7 @@ public class Water implements ForwardingProfile.LayerPostProcessor {
 
   public void processPreparedOsm(SourceFeature ignoredSf, FeatureCollector features) {
     features.polygon(LAYER_NAME)
-      .setId(0)
+      .setId(1)
       .setAttr("kind", "ocean")
       .setAttr("sort_rank", 200)
       .setPixelTolerance(Earth.PIXEL_TOLERANCE)

--- a/tiles/src/test/java/com/protomaps/basemap/layers/EarthTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/EarthTest.java
@@ -14,7 +14,7 @@ class EarthTest extends LayerTest {
   @Test
   void simple() {
     assertFeatures(15,
-      List.of(Map.of("_id", 0L, "kind", "earth")),
+      List.of(Map.of("_id", 1L, "kind", "earth")),
       process(SimpleFeature.create(
         newPolygon(0, 0, 0, 1, 1, 1, 0, 0),
         new HashMap<>(Map.of()),

--- a/tiles/src/test/java/com/protomaps/basemap/layers/EarthTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/EarthTest.java
@@ -41,6 +41,7 @@ class EarthTest extends LayerTest {
   void testNe() {
     assertFeatures(15,
       List.of(Map.of("kind", "earth",
+        "_id", 1L,
         "_minzoom", 0,
         "_maxzoom", 4)),
       process(SimpleFeature.create(

--- a/tiles/src/test/java/com/protomaps/basemap/layers/LandcoverTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/LandcoverTest.java
@@ -24,7 +24,7 @@ class LandcoverTest extends LayerTest {
   })
   void simple(String daylightClassString, String expectedString, Integer expectedSortKey) {
     assertFeatures(7,
-      List.of(Map.of("kind", expectedString, "_sortkey", expectedSortKey)),
+      List.of(Map.of("kind", expectedString, "_sortkey", expectedSortKey, "_id", 1L + expectedSortKey)),
       process(SimpleFeature.create(
         newPolygon(0, 0, 0, 1, 1, 1, 0, 0),
         new HashMap<>(Map.of("class", daylightClassString)),

--- a/tiles/src/test/java/com/protomaps/basemap/layers/WaterTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/WaterTest.java
@@ -12,7 +12,7 @@ class WaterTest extends LayerTest {
   @Test
   void preparedOsm() {
     assertFeatures(15,
-      List.of(Map.of("_id", 0L, "kind", "ocean")),
+      List.of(Map.of("_id", 1L, "kind", "ocean")),
       process(SimpleFeature.create(
         newPolygon(0, 0, 0, 1, 1, 1, 0, 0),
         new HashMap<>(Map.of()),


### PR DESCRIPTION
* assign IDs based on landcover class

https://github.com/onthegomap/planetiler/blob/main/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java#L88 is where 0 never makes it into the vector tiles, which also screws up IDs after post process-merging. 