### PR TITLE
Minzoom based styling

### DIFF
--- a/styles/src/base_layers.ts
+++ b/styles/src/base_layers.ts
@@ -406,7 +406,10 @@ export function nolabels_layers(
         "all",
         ["!has", "is_tunnel"],
         ["!has", "is_bridge"],
-        ["==", "kind", "major_road"],
+        ["any",
+          ["==", "kind", "major_road"],
+          ["==", "min_zoom", 7]
+        ]
       ],
       paint: {
         "line-color": t.tunnel_major_casing,
@@ -442,7 +445,7 @@ export function nolabels_layers(
         "all",
         ["!has", "is_tunnel"],
         ["!has", "is_bridge"],
-        ["==", "kind", "highway"],
+        ["==", "min_zoom", 4],
         ["!has", "is_link"],
       ],
       paint: {
@@ -541,7 +544,10 @@ export function nolabels_layers(
       type: "line",
       source: source,
       "source-layer": "roads",
-      filter: ["all", ["has", "is_tunnel"], ["==", "kind", "major_road"]],
+      filter: ["all", ["has", "is_tunnel"], ["any",
+        ["==", "kind", "major_road"],
+        ["==", "min_zoom", 7]
+      ]],
       paint: {
         "line-color": t.tunnel_major,
         "line-width": [
@@ -735,7 +741,10 @@ export function nolabels_layers(
         "all",
         ["!has", "is_tunnel"],
         ["!has", "is_bridge"],
-        ["==", "kind", "major_road"],
+        ["any",
+          ["==", "kind", "major_road"],
+          ["==", "min_zoom", 7]
+        ],
       ],
       paint: {
         "line-color": t.major_casing_late,
@@ -773,7 +782,7 @@ export function nolabels_layers(
         "all",
         ["!has", "is_tunnel"],
         ["!has", "is_bridge"],
-        ["==", "kind", "highway"],
+        ["==", "min_zoom", 4],
         ["!has", "is_link"],
       ],
       paint: {
@@ -921,7 +930,10 @@ export function nolabels_layers(
         "all",
         ["!has", "is_tunnel"],
         ["!has", "is_bridge"],
-        ["==", "kind", "major_road"],
+        ["any",
+          ["==", "kind", "major_road"],
+          ["==", "min_zoom", 7]
+        ],
       ],
       paint: {
         "line-color": t.major_casing_early,
@@ -956,7 +968,10 @@ export function nolabels_layers(
         "all",
         ["!has", "is_tunnel"],
         ["!has", "is_bridge"],
-        ["==", "kind", "major_road"],
+        ["any",
+          ["==", "kind", "major_road"],
+          ["==", "min_zoom", 7]
+        ],
       ],
       paint: {
         "line-color": t.major,
@@ -985,7 +1000,7 @@ export function nolabels_layers(
         "all",
         ["!has", "is_tunnel"],
         ["!has", "is_bridge"],
-        ["==", "kind", "highway"],
+        ["==", "min_zoom", 4],
         ["!has", "is_link"],
       ],
       paint: {
@@ -1021,7 +1036,7 @@ export function nolabels_layers(
         "all",
         ["!has", "is_tunnel"],
         ["!has", "is_bridge"],
-        ["==", "kind", "highway"],
+        ["==", "min_zoom", 4],
         ["!has", "is_link"],
       ],
       paint: {
@@ -1192,7 +1207,10 @@ export function nolabels_layers(
       source: source,
       "source-layer": "roads",
       minzoom: 12,
-      filter: ["all", ["has", "is_bridge"], ["==", "kind", "major_road"]],
+      filter: ["all", ["has", "is_bridge"], ["any",
+        ["==", "kind", "major_road"],
+        ["==", "min_zoom", 7]
+      ]],
       paint: {
         "line-color": t.bridges_major_casing,
         "line-gap-width": [
@@ -1290,7 +1308,10 @@ export function nolabels_layers(
       source: source,
       "source-layer": "roads",
       minzoom: 12,
-      filter: ["all", ["has", "is_bridge"], ["==", "kind", "major_road"]],
+      filter: ["all", ["has", "is_bridge"], ["any",
+        ["==", "kind", "major_road"],
+        ["==", "min_zoom", 7]
+      ]],
       paint: {
         "line-color": t.bridges_major,
         "line-width": [
@@ -1317,7 +1338,7 @@ export function nolabels_layers(
       filter: [
         "all",
         ["has", "is_bridge"],
-        ["==", "kind", "highway"],
+        ["==", "min_zoom", 4],
         ["!has", "is_link"],
       ],
       paint: {
@@ -1354,7 +1375,7 @@ export function nolabels_layers(
       filter: [
         "all",
         ["has", "is_bridge"],
-        ["==", "kind", "highway"],
+        ["==", "min_zoom", 4],
         ["!has", "is_link"],
       ],
       paint: {


### PR DESCRIPTION
Although the tiles contain now nicely non-fragmented highways in the US, we still have a fragmented display at zoom 6 for example because the styles are not yet adjusted.

See Madison near Chicago for example: 
https://maps.protomaps.com/#flavorName=light&lang=en&map=6/43.263/-89.148

Explores how styling could be done with minzoom filtering, but actually I don't think this is the right approach. 

What we really should do is to demote the `kind` of non-interstate highways in the US from `kind=highway` to `kind=major_road`. Similarly, interstate `highway=trunk` should be promoted from `kind=major_road` to `kind=highway`.
