### PR TITLE
set min earth size back to 1px

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
@@ -16,7 +16,7 @@ public class Earth implements ForwardingProfile.LayerPostProcessor {
   public static final String LAYER_NAME = "earth";
 
   public static final double BUFFER = 0.0625;
-  public static final double MIN_AREA = 10.0;
+  public static final double MIN_AREA = 1.0;
 
   public static final double PIXEL_TOLERANCE = 0.2;
 
@@ -30,7 +30,6 @@ public class Earth implements ForwardingProfile.LayerPostProcessor {
       .setId(1)
       .setAttr("kind", "earth")
       .setPixelTolerance(PIXEL_TOLERANCE)
-      .setMinPixelSize(1.0)
       .setMinZoom(6)
       .setBufferPixels(8);
   }


### PR DESCRIPTION
![CleanShot 2025-03-21 at 13 13 43@2x](https://github.com/user-attachments/assets/49130128-d58c-4a3c-be6c-06435aa8937c)

make sure taiwan and most of the philippine archipelago shows up at zoom=0 instead of disappearing. 

The planet build size is 120.3 GB