### PR TITLE
Export get_multiline_name and get_country_name

### DIFF
--- a/styles/src/index.ts
+++ b/styles/src/index.ts
@@ -1,7 +1,11 @@
 import { LayerSpecification } from "@maplibre/maplibre-gl-style-spec";
 import { labels_layers, nolabels_layers } from "./base_layers";
 import { BLACK, DARK, Flavor, GRAYSCALE, LIGHT, Pois, WHITE } from "./flavors";
-import { language_script_pairs, get_multiline_name, get_country_name } from "./language";
+import {
+  language_script_pairs,
+  get_multiline_name,
+  get_country_name,
+} from "./language";
 
 export { language_script_pairs, get_multiline_name, get_country_name };
 export type { Pois, Flavor };

--- a/styles/src/index.ts
+++ b/styles/src/index.ts
@@ -1,9 +1,9 @@
 import { LayerSpecification } from "@maplibre/maplibre-gl-style-spec";
 import { labels_layers, nolabels_layers } from "./base_layers";
 import { BLACK, DARK, Flavor, GRAYSCALE, LIGHT, Pois, WHITE } from "./flavors";
-import { language_script_pairs } from "./language";
+import { language_script_pairs, get_multiline_name, get_country_name } from "./language";
 
-export { language_script_pairs };
+export { language_script_pairs, get_multiline_name, get_country_name };
 export type { Pois, Flavor };
 export { LIGHT, DARK, WHITE, GRAYSCALE, BLACK };
 


### PR DESCRIPTION
I've had to fork the style to customise it, but it would be nicer to import these functions rather than copy them.