### PR TITLE
Make the style work with older tile builds missing sort_rank [#436]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Tiles 4.9.0, Styles 5.1.0
+------
+- Use sort_rank to order places correctly across tile boundaries [#436, #434]
+
 Tiles 4.8.2
 ------
 - port places to use Matchers [#434]

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.css" crossorigin="anonymous">
         <script src="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.js" crossorigin="anonymous"></script>
         <script src="https://unpkg.com/pmtiles@4.2.1/dist/pmtiles.js"></script>
-        <script src="https://unpkg.com/@protomaps/basemaps@5.0.2/dist/basemaps.js"></script>
+        <script src="https://unpkg.com/@protomaps/basemaps@5.1.0/dist/basemaps.js"></script>
         <style>
             body {
                 margin: 0;

--- a/examples/data_sandwich.html
+++ b/examples/data_sandwich.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.css" crossorigin="anonymous">
         <script src="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.js" crossorigin="anonymous"></script>
         <script src="https://unpkg.com/pmtiles@4.2.1/dist/pmtiles.js"></script>
-        <script src="https://unpkg.com/@protomaps/basemaps@5.0.2/dist/basemaps.js"></script>
+        <script src="https://unpkg.com/@protomaps/basemaps@5.1.0/dist/basemaps.js"></script>
         <style>
             body {
                 margin: 0;

--- a/examples/theme_language.html
+++ b/examples/theme_language.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.css" crossorigin="anonymous">
         <script src="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.js" crossorigin="anonymous"></script>
         <script src="https://unpkg.com/pmtiles@4.2.1/dist/pmtiles.js"></script>
-        <script src="https://unpkg.com/@protomaps/basemaps@5.0.2/dist/basemaps.js"></script>
+        <script src="https://unpkg.com/@protomaps/basemaps@5.1.0/dist/basemaps.js"></script>
         <style>
             body {
                 margin: 0;

--- a/styles/package-lock.json
+++ b/styles/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@protomaps/basemaps",
-  "version": "5.0.2",
+  "version": "5.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@protomaps/basemaps",
-      "version": "5.0.2",
+      "version": "5.1.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@biomejs/biome": "^1.5.3",

--- a/styles/package.json
+++ b/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protomaps/basemaps",
-  "version": "5.0.2",
+  "version": "5.1.0",
   "description": "Protomaps basemap style for MapLibre GL",
   "type": "module",
   "main": "dist/cjs/index.cjs",

--- a/styles/src/base_layers.ts
+++ b/styles/src/base_layers.ts
@@ -1686,7 +1686,7 @@ export function labels_layers(
       "source-layer": "places",
       filter: ["==", "kind", "neighbourhood"],
       layout: {
-        "symbol-sort-key": ["get", "sort_key"],
+        "symbol-sort-key": ["case", ["has", "sort_key"], ["get","sort_key"], ["get","min_zoom"]],
         "text-field": get_multiline_name(
           lang,
           script,
@@ -1747,7 +1747,7 @@ export function labels_layers(
           ["literal", [t.bold || "Noto Sans Medium"]],
           ["literal", [t.regular || "Noto Sans Regular"]],
         ],
-        "symbol-sort-key": ["get", "sort_key"],
+        "symbol-sort-key": ["case", ["has", "sort_key"], ["get","sort_key"], ["get","min_zoom"]],
         "text-padding": [
           "interpolate",
           ["linear"],
@@ -1850,7 +1850,7 @@ export function labels_layers(
       "source-layer": "places",
       filter: ["==", "kind", "region"],
       layout: {
-        "symbol-sort-key": ["get", "sort_key"],
+        "symbol-sort-key": ["case", ["has", "sort_key"], ["get","sort_key"], ["get","min_zoom"]],
         "text-field": [
           "step",
           ["zoom"],
@@ -1881,7 +1881,7 @@ export function labels_layers(
       "source-layer": "places",
       filter: ["==", "kind", "country"],
       layout: {
-        "symbol-sort-key": ["get", "sort_key"],
+        "symbol-sort-key": ["case", ["has", "sort_key"], ["get","sort_key"], ["get","min_zoom"]],
         "text-field": get_country_name(
           lang,
           script,

--- a/styles/src/base_layers.ts
+++ b/styles/src/base_layers.ts
@@ -1686,7 +1686,12 @@ export function labels_layers(
       "source-layer": "places",
       filter: ["==", "kind", "neighbourhood"],
       layout: {
-        "symbol-sort-key": ["case", ["has", "sort_key"], ["get","sort_key"], ["get","min_zoom"]],
+        "symbol-sort-key": [
+          "case",
+          ["has", "sort_key"],
+          ["get", "sort_key"],
+          ["get", "min_zoom"],
+        ],
         "text-field": get_multiline_name(
           lang,
           script,
@@ -1747,7 +1752,12 @@ export function labels_layers(
           ["literal", [t.bold || "Noto Sans Medium"]],
           ["literal", [t.regular || "Noto Sans Regular"]],
         ],
-        "symbol-sort-key": ["case", ["has", "sort_key"], ["get","sort_key"], ["get","min_zoom"]],
+        "symbol-sort-key": [
+          "case",
+          ["has", "sort_key"],
+          ["get", "sort_key"],
+          ["get", "min_zoom"],
+        ],
         "text-padding": [
           "interpolate",
           ["linear"],
@@ -1850,7 +1860,12 @@ export function labels_layers(
       "source-layer": "places",
       filter: ["==", "kind", "region"],
       layout: {
-        "symbol-sort-key": ["case", ["has", "sort_key"], ["get","sort_key"], ["get","min_zoom"]],
+        "symbol-sort-key": [
+          "case",
+          ["has", "sort_key"],
+          ["get", "sort_key"],
+          ["get", "min_zoom"],
+        ],
         "text-field": [
           "step",
           ["zoom"],
@@ -1881,7 +1896,12 @@ export function labels_layers(
       "source-layer": "places",
       filter: ["==", "kind", "country"],
       layout: {
-        "symbol-sort-key": ["case", ["has", "sort_key"], ["get","sort_key"], ["get","min_zoom"]],
+        "symbol-sort-key": [
+          "case",
+          ["has", "sort_key"],
+          ["get", "sort_key"],
+          ["get", "min_zoom"],
+        ],
         "text-field": get_country_name(
           lang,
           script,

--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -116,7 +116,7 @@ public class Basemap extends ForwardingProfile {
 
   @Override
   public String version() {
-    return "4.8.2";
+    return "4.9.0";
   }
 
   @Override


### PR DESCRIPTION
@wipfli without this we get console warnings `Expected value to be of type number, but found null instead.` if the style depends on `sort_rank` but the tileset is a 4.x that doesn't contain it.

If we didn't want to do this then we would require a SemVer bump for this kind of change which seems painful. 