### PR TITLE
Add Burmese support

### DIFF
--- a/app/src/MapView.tsx
+++ b/app/src/MapView.tsx
@@ -152,11 +152,11 @@ function getMaplibreStyle(
   if (localSprites) {
     style.sprite = `${location.protocol}//${location.host}/${flavorName}`;
   } else {
-    style.sprite = `https://protomaps.github.io/basemaps-assets/sprites/v4/${flavorName}`;
+    style.sprite = `https://wipfli.github.io/basemaps-assets/sprites/v4/${flavorName}`;
   }
 
   style.glyphs =
-    "https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf";
+    "https://wipfli.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf";
 
   style.sources = {
     protomaps: {

--- a/styles/src/generate_style.ts
+++ b/styles/src/generate_style.ts
@@ -30,9 +30,9 @@ const style = {
     },
   },
   layers: layers("protomaps", flavor, { lang: lang }),
-  sprite: `https://protomaps.github.io/basemaps-assets/sprites/v4/${flavorName}`,
+  sprite: `https://wipfli.github.io/basemaps-assets/sprites/v4/${flavorName}`,
   glyphs:
-    "https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf",
+    "https://wipfli.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf",
 };
 
 await writeFile(out, JSON.stringify(style, null, 2));

--- a/styles/src/language.ts
+++ b/styles/src/language.ts
@@ -19,6 +19,8 @@ function get_name_block(
         "case",
         ["==", ["get", script], "Devanagari"],
         ["literal", ["Noto Sans Devanagari Regular v1"]],
+        ["==", ["get", script], "Myanmar"],
+        ["literal", ["Zawgyi One Regular"]],
         ["literal", [regular || "Noto Sans Regular"]],
       ],
     },
@@ -62,6 +64,11 @@ function get_font_formatting(script: string) {
       "text-font": ["literal", ["Noto Sans Devanagari Regular v1"]],
     };
   }
+  if (script === "Myanmar") {
+    return {
+      "text-font": ["literal", ["Zawgyi One Regular"]],
+    };
+  }
   return {};
 }
 
@@ -73,7 +80,7 @@ function get_default_script(lang: string) {
 export function get_country_name(lang: string, script?: string) {
   const _script = script || get_default_script(lang);
   let name_prefix: string;
-  if (_script === "Devanagari") {
+  if (_script === "Devanagari" || _script === "Myanmar") {
     name_prefix = "pgf:";
   } else {
     name_prefix = "";
@@ -92,7 +99,7 @@ export function get_multiline_name(
 ) {
   const _script = script || get_default_script(lang);
   let name_prefix: string;
-  if (_script === "Devanagari") {
+  if (_script === "Devanagari" || _script === "Myanmar") {
     name_prefix = "pgf:";
   } else {
     name_prefix = "";
@@ -142,6 +149,8 @@ export function get_multiline_name(
               "case",
               ["==", ["get", "script"], "Devanagari"],
               ["literal", ["Noto Sans Devanagari Regular v1"]],
+              ["==", ["get", "script"], "Myanmar"],
+              ["literal", ["Zawgyi One Regular"]],
               ["literal", [regular || "Noto Sans Regular"]],
             ],
           },

--- a/tiles/pom.xml
+++ b/tiles/pom.xml
@@ -57,6 +57,12 @@
       <version>${planetiler.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.myanmartools</groupId>
+      <artifactId>myanmar-tools</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+
     <!-- To use test utilities: -->
     <dependency>
       <groupId>com.onthegomap.planetiler</groupId>

--- a/tiles/src/main/java/com/protomaps/basemap/text/TextEngine.java
+++ b/tiles/src/main/java/com/protomaps/basemap/text/TextEngine.java
@@ -1,5 +1,6 @@
 package com.protomaps.basemap.text;
 
+import com.google.myanmartools.TransliterateU2Z;
 import com.protomaps.basemap.names.Script;
 import java.awt.Font;
 import java.awt.font.FontRenderContext;
@@ -11,8 +12,9 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-
 public class TextEngine {
+
+  private static final TransliterateU2Z unicodeToZawgyiConverter = new TransliterateU2Z("Unicode to Zawgyi");
 
   private static Integer[][] deltas = new Integer[][]{
     {0, 0},
@@ -151,6 +153,8 @@ public class TextEngine {
       String script = Script.getScript(segment);
       if (fontRegistry.getScripts().contains(script)) {
         encodedText += TextEngine.encode(segment, fontRegistry.getFont(script), fontRegistry.getEncoding(script));
+      } else if (script.equals("Myanmar")) {
+        encodedText += unicodeToZawgyiConverter.convert(segment);
       } else {
         encodedText += segment;
       }

--- a/tiles/src/test/java/com/protomaps/basemap/layers/PlacesTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/PlacesTest.java
@@ -189,4 +189,23 @@ class PlacesTest extends LayerTest {
         0
       )));
   }
+
+  @Test
+  void testMyanmar() {
+    assertFeatures(14,
+      List.of(Map.of(
+        "kind", "country",
+        "name", "Myanmar",
+        "name2", "မြန်မာနိုင်ငံ",
+        "script2", "Myanmar"
+      // "pgf:name2", "ျမန္မာနိုင္ငံ"
+      )),
+      process(SimpleFeature.create(
+        newPoint(1, 1),
+        new HashMap<>(Map.of("place", "country", "name", "Myanmar မြန်မာနိုင်ငံ")),
+        "osm",
+        null,
+        0
+      )));
+  }
 }


### PR DESCRIPTION
Introduces support for Burmese text rendering by converting Unicode Burmese text to Zawgyi encoding.

Demo available at https://jsbin.com/gunigijatu/edit?html,output
