### PR TITLE
import only types from @maplibre/maplibre-gl-style-spec

### DIFF
--- a/styles/src/base_layers.ts
+++ b/styles/src/base_layers.ts
@@ -1,7 +1,7 @@
 import {
-  DataDrivenPropertyValueSpecification,
-  ExpressionSpecification,
-  LayerSpecification,
+  type DataDrivenPropertyValueSpecification,
+  type ExpressionSpecification,
+  type LayerSpecification,
 } from "@maplibre/maplibre-gl-style-spec";
 import { Flavor } from "./flavors";
 import { get_country_name, get_multiline_name } from "./language";

--- a/styles/src/index.ts
+++ b/styles/src/index.ts
@@ -1,4 +1,4 @@
-import { LayerSpecification } from "@maplibre/maplibre-gl-style-spec";
+import { type LayerSpecification } from "@maplibre/maplibre-gl-style-spec";
 import { labels_layers, nolabels_layers } from "./base_layers";
 import { BLACK, DARK, Flavor, GRAYSCALE, LIGHT, Pois, WHITE } from "./flavors";
 import {


### PR DESCRIPTION
@wipfli I am trying to make it so that projects depending on `@protomaps/basemaps` do not need to bring in maplibre-style-spec as a dependency