### PR TITLE
Use text-variable-anchor

### DIFF
--- a/styles/src/base_layers.ts
+++ b/styles/src/base_layers.ts
@@ -1878,11 +1878,11 @@ export function labels_layers(
         "text-variable-anchor": [
           "step",
           ["zoom"],
-          ["literal", ["bottom-left", "top-left", "bottom-right", "top-right"]],
+          ["literal", ["bottom", "left", "right", "top"]],
           8,
           ["literal", ["center"]],
         ],
-        "text-radial-offset": ["step", ["zoom"], 0.1, 6, 0.0],
+        "text-radial-offset": 0.3,
       },
       paint: {
         "text-color": t.city_label,

--- a/styles/src/base_layers.ts
+++ b/styles/src/base_layers.ts
@@ -1882,13 +1882,7 @@ export function labels_layers(
           8,
           ["literal", ["center"]],
         ],
-        "text-radial-offset": [
-          "step",
-          ["zoom"],
-          0.1,
-          6,
-          0.0
-        ],
+        "text-radial-offset": ["step", ["zoom"], 0.1, 6, 0.0],
       },
       paint: {
         "text-color": t.city_label,

--- a/styles/src/base_layers.ts
+++ b/styles/src/base_layers.ts
@@ -1875,8 +1875,14 @@ export function labels_layers(
           2,
         ],
         "text-justify": "auto",
-        "text-anchor": ["step", ["zoom"], "left", 8, "center"],
-        "text-radial-offset": 0.4,
+        "text-variable-anchor": [
+          "step",
+          ["zoom"],
+          ["literal", ["bottom", "left", "right"]],
+          8,
+          ["literal", ["center"]],
+        ],
+        "text-radial-offset": 0.3,
       },
       paint: {
         "text-color": t.city_label,

--- a/styles/src/base_layers.ts
+++ b/styles/src/base_layers.ts
@@ -1878,11 +1878,17 @@ export function labels_layers(
         "text-variable-anchor": [
           "step",
           ["zoom"],
-          ["literal", ["bottom", "left", "right"]],
+          ["literal", ["bottom-left", "top-left", "bottom-right", "top-right"]],
           8,
           ["literal", ["center"]],
         ],
-        "text-radial-offset": 0.3,
+        "text-radial-offset": [
+          "step",
+          ["zoom"],
+          0.1,
+          6,
+          0.0
+        ],
       },
       paint: {
         "text-color": t.city_label,


### PR DESCRIPTION
MapLibre GL can place text labels such that the anchor, i.e., the icon/symbolizer location, is to the left, right, top, or bottom of the label. So far we are only using labels where the anchor is to the left.

This pull request proposes to have a variable anchor, with bottom taking precedence over left, and right. As a result, more labels can be shown which is convenient in dense areas.

Demo: https://wipfli.github.io/debug-assets/text-variable-anchor/index.html#map=1.99/0/0
