### PR TITLE
app: resize map on load to work around Safari CSS issues

### DIFF
--- a/app/src/MapView.tsx
+++ b/app/src/MapView.tsx
@@ -303,6 +303,10 @@ function MapLibreView(props: {
       maxWidth: "none",
     });
 
+    map.on("load", () => {
+      map.resize();
+    });
+
     map.on("error", (e) => {
       setError(e.error.message);
     });


### PR DESCRIPTION
@wipfli this is to work around a Safari issue which I think is a race condition - the map initialization and size detection completes before the CSS stylesheet is loaded, meaning that the map is initialized to the wrong size. I consistently see this in Vite-based MapLibre applications only on Safari/Mobile Safari, so this is a hack that calls resize once the map is loaded. 
![image](https://github.com/user-attachments/assets/344c40a7-a5ab-4526-82e5-fec129fd7089)
