### PR TITLE
Suppress duplicated string literals warning in layer classes

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Boundaries.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Boundaries.java
@@ -13,6 +13,7 @@ import com.protomaps.basemap.feature.FeatureId;
 import java.util.List;
 import java.util.OptionalInt;
 
+@SuppressWarnings("java:S1192")
 public class Boundaries implements ForwardingProfile.OsmRelationPreprocessor,
   ForwardingProfile.LayerPostProcessor {
 

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Buildings.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Buildings.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+@SuppressWarnings("java:S1192")
 public class Buildings implements ForwardingProfile.LayerPostProcessor {
 
   static final String HEIGHT_KEY = "height";

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Earth.java
@@ -10,7 +10,7 @@ import com.protomaps.basemap.feature.FeatureId;
 import com.protomaps.basemap.names.OsmNames;
 import java.util.List;
 
-@SuppressWarnings("java:S1192") // Duplicated string literals
+@SuppressWarnings("java:S1192")
 public class Earth implements ForwardingProfile.LayerPostProcessor {
 
   public static final String LAYER_NAME = "earth";

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landcover.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Map;
 import org.locationtech.jts.geom.Point;
 
-@SuppressWarnings("java:S1192") // Duplicated string literals
+@SuppressWarnings("java:S1192")
 public class Landcover implements ForwardingProfile.LayerPostProcessor {
 
   static final Map<String, String> kindMapping = Map.of("urban", "urban_area", "crop", "farmland", "grass", "grassland",

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 
+@SuppressWarnings("java:S1192")
 public class Landuse implements ForwardingProfile.LayerPostProcessor {
 
   private static final String US_FOREST_OPERATORS = """

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("java:S1192")
 public class Places implements ForwardingProfile.LayerPostProcessor {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Places.class);

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -14,6 +14,7 @@ import com.protomaps.basemap.feature.QrankDb;
 import com.protomaps.basemap.names.OsmNames;
 import java.util.List;
 
+@SuppressWarnings("java:S1192")
 public class Pois implements ForwardingProfile.LayerPostProcessor {
 
   private QrankDb qrankDb;

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -24,6 +24,7 @@ import com.protomaps.basemap.locales.US;
 import com.protomaps.basemap.names.OsmNames;
 import java.util.*;
 
+@SuppressWarnings("java:S1192")
 public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingProfile.OsmRelationPreprocessor {
 
   private CountryCoder countryCoder;

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Water.java
@@ -25,7 +25,7 @@ import com.protomaps.basemap.names.OsmNames;
 import java.util.List;
 import java.util.Map;
 
-@SuppressWarnings("java:S1192") // Duplicated string literals
+@SuppressWarnings("java:S1192")
 public class Water implements ForwardingProfile.LayerPostProcessor {
 
   private static final double WORLD_AREA_FOR_70K_SQUARE_METERS =


### PR DESCRIPTION
We have 83 open issues related to S1192 duplicated string literals: https://sonarcloud.io/project/issues?rules=java%3AS1192&issueStatuses=OPEN%2CCONFIRMED&id=protomaps_basemaps

Those should all be closed with this pull request, bringing the total sonar issue count down from 164 to 81.