### PR TITLE
Revert addGeopackage to addNaturalEarthSource

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -167,7 +167,7 @@ public class Basemap extends ForwardingProfile {
     String area = args.getString("area", "geofabrik area to download", "monaco");
 
     var planetiler = Planetiler.create(args)
-      .addGeoPackageSource("ne", nePath, neUrl)
+      .addNaturalEarthSource("ne", nePath, neUrl)
       .addOsmSource("osm", Path.of("data", "sources", area + ".osm.pbf"), "geofabrik:" + area)
       .addShapefileSource("osm_water", sourcesDir.resolve("water-polygons-split-3857.zip"),
         "https://osmdata.openstreetmap.de/download/water-polygons-split-3857.zip")


### PR DESCRIPTION
Though that method is deprecated:

```
Planetiler com.onthegomap.planetiler.Planetiler.addNaturalEarthSource(String name, Path defaultPath, String defaultUrl)
Deprecated. can be replaced by addGeoPackageSource(String, Path, String).

Adds a new Natural Earth sqlite file source that will be processed when run() is called.

If the file does not exist and download=true argument is set, then the file will first be downloaded from defaultUrl.

To override the location of the sqlite file, set name_path=newpath.zip in the arguments and to override the download URL set name_url=http://url/of/natural_earth.zip.
```

@msbarry the build crashed when replacing natural earth with geopackage source. Do you have an example of how this should be done?
