### PR TITLE
chore: improved Dockerfile to utilize cached layers

### DIFF
--- a/tiles/Dockerfile
+++ b/tiles/Dockerfile
@@ -1,6 +1,21 @@
-FROM maven:3-eclipse-temurin-22-alpine
+# Stage 1: Build
+FROM maven:3-eclipse-temurin-22-alpine AS build
 WORKDIR /tiles
-COPY src src
+
+# Copy pom.xml and download dependencies separately to create a cached layer
 COPY pom.xml pom.xml
+RUN mvn dependency:go-offline
+
+# Then copy source code and build
+COPY src src
 RUN mvn clean package
-ENTRYPOINT ["java","-jar","/tiles/target/protomaps-basemap-HEAD-with-deps.jar"]
+
+# Stage 2: Runtime
+FROM eclipse-temurin:22-jre-alpine
+WORKDIR /tiles
+
+# Copy only the built jar from the build stage
+COPY --from=build /tiles/target/protomaps-basemap-HEAD-with-deps.jar /tiles/protomaps-basemap.jar
+
+# Run the application
+ENTRYPOINT ["java", "-jar", "/tiles/protomaps-basemap.jar"]


### PR DESCRIPTION
It was kind of annoying to me, doing a complete refetch of the dependencies on each build within docker.