### PR TITLE
Do not run tile version bump check on main

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,6 +19,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Check for required version bump
+      if: github.ref_name != 'main'
       run: |
         git fetch origin main:main
         .github/workflows/check-version-bump.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Tiles 4.11.7
 ------
-- Render access=no,private roads only at zoom 15 [#491]()
+- Render access=no,private roads only at zoom 15 [#491]
 
 Styles 5.4.1
 ------


### PR DESCRIPTION
Fixes CI on main which currently fails like this:

![image](https://github.com/user-attachments/assets/d5273828-0f1e-42f1-8388-215006d42ac6)
