### PR TITLE
Remove unused landuse kinds

### DIFF
--- a/styles/src/base_layers.ts
+++ b/styles/src/base_layers.ts
@@ -251,16 +251,6 @@ export function nolabels_layers(
       },
     },
     {
-      id: "unused_landuse",
-      type: "fill",
-      source: source,
-      "source-layer": "landuse",
-      filter: ["in", "kind", "bare_rock"],
-      paint: {
-        "fill-color": "red",
-      },
-    },
-    {
       id: "water",
       type: "fill",
       filter: ["==", "$type", "Polygon"],

--- a/styles/src/base_layers.ts
+++ b/styles/src/base_layers.ts
@@ -251,6 +251,16 @@ export function nolabels_layers(
       },
     },
     {
+      id: "unused_landuse",
+      type: "fill",
+      source: source,
+      "source-layer": "landuse",
+      filter: ["in", "kind", "bare_rock"],
+      paint: {
+        "fill-color": "red",
+      },
+    },
+    {
       id: "water",
       type: "fill",
       filter: ["==", "$type", "Polygon"],

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
@@ -239,12 +239,9 @@ public class Landuse implements ForwardingProfile.LayerPostProcessor {
       String kind = getString(sf, matches, "kind", "other");
 
       features.polygon(this.name())
-        .setId(FeatureId.create(sf))
+        .setId(1)
         // Core Tilezen schema properties
         .setAttr("kind", kind)
-        .setAttr("sort_rank", 189)
-        // NOTE: (nvkelso 20230622) Consider zoom 5 instead...
-        //       But to match Protomaps v2 we do earlier
         .setZoomRange(2, 15)
         .setMinPixelSize(2.0);
 
@@ -260,20 +257,6 @@ public class Landuse implements ForwardingProfile.LayerPostProcessor {
 
   @Override
   public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) throws GeometryException {
-    if (zoom == 15)
-      return items;
-    int minArea = 400 / (4096 * 4096) * (256 * 256);
-    if (zoom == 6)
-      minArea = 600 / (4096 * 4096) * (256 * 256);
-    else if (zoom <= 5)
-      minArea = 800 / (4096 * 4096) * (256 * 256);
-    items = Area.filterArea(items, minArea);
-
-    // We only care about park boundaries inside groups of adjacent parks at higher zooms when they are labeled
-    // so at lower zooms we merge them to reduce file size
-    if (zoom <= 6) {
-      return FeatureMerge.mergeNearbyPolygons(items, 3.125, 3.125, 0.5, 0.5);
-    }
-    return items;
+    return FeatureMerge.mergeNearbyPolygons(items, 3.125, 3.125, 0.5, 0.5);
   }
 }

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
@@ -95,13 +95,10 @@ public class Landuse implements ForwardingProfile.LayerPostProcessor {
           cemetery
           commercial
           grass
-          farmland
-          residential
           military
           village_green
           allotments
           forest
-          meadow
           grass
         """),
       use("kind", fromTag("landuse"))
@@ -132,8 +129,6 @@ public class Landuse implements ForwardingProfile.LayerPostProcessor {
           grassland
           scrub
           sand
-          wetland
-          bare_rock
         """),
       use("kind", fromTag("natural"))
     ),
@@ -166,10 +161,6 @@ public class Landuse implements ForwardingProfile.LayerPostProcessor {
     rule(
       with("landuse", "brownfield"),
       use("kind", "industrial")
-    ),
-    rule(
-      with("landuse", "farmyard", "orchard"),
-      use("kind", "farmland")
     ),
     rule(
       with("man_made", "bridge"),

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
@@ -177,7 +177,7 @@ public class Landuse implements ForwardingProfile.LayerPostProcessor {
     ),
     rule(
       with("area:aeroway", "taxiway", "runway"),
-      use("kind", "other")
+      use("kind", fromTag("area:aeroway"))
     ),
     rule(
       with("place", "neighbourhood"),

--- a/tiles/src/test/java/com/protomaps/basemap/layers/LanduseTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/LanduseTest.java
@@ -39,6 +39,16 @@ class LanduseTest extends LayerTest {
       List.of(Map.of("kind", "runway")),
       processWith("aeroway", "runway")
     );
+
+    assertFeatures(15,
+      List.of(Map.of("kind", "runway")),
+      processWith("area:aeroway", "runway")
+    );
+
+    assertFeatures(15,
+      List.of(Map.of("kind", "taxiway")),
+      processWith("area:aeroway", "taxiway")
+    );
   }
 
   @Test


### PR DESCRIPTION
Removes unused landuse kinds and changes a little the layer post processing.

Planet build with `--layer=landuse` goes from 35 GB (100%) on main to 18 GB (51%) on this branch.
