### PR TITLE
Reduce minZoom for subway

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -239,10 +239,13 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
           monorail
           narrow_gauge
           preserved
-          subway
           tram
         """),
       use("minZoom", 14)
+    ),
+    rule(
+      with("railway", "subway"),
+      use("minZoom", 11)
     ),
     rule(
       with("railway", "disused"),


### PR DESCRIPTION
hey there Brandon et al - I'm a huge fan of the project.

I'd like to propose reducing the `minZoom`  for the subway road-layer data. My motivation is to see a city's subway network from the zoom level of a normal city. This layer is currently working great, but only at a very-close zoom.

Please let me know if this change is appropriate, or can be improved. I know there are a lot of plans for future transit data. This subway data is not shown in any of the default basemap flavours, so may have a minimal impact.
cheers