### PR TITLE
Update base_layers.ts: add 3D

### DIFF
--- a/styles/src/base_layers.ts
+++ b/styles/src/base_layers.ts
@@ -601,34 +601,22 @@ export function nolabels_layers(
       },
     },
     {
-      "id": "3d-buildings",
-      "source": "protomaps",
+      id: "3d-buildings",
+      source: "protomaps",
       "source-layer": "buildings",
-      "type": "fill-extrusion",
-      "paint": {
+      type: "fill-extrusion",
+      paint: {
         "fill-extrusion-color": t.buildings,
         "fill-extrusion-height": [
           "case",
-          [
-            "has",
-            "height"
-          ],
-          [
-            "get",
-            "height"
-          ],
-          [
-            "has",
-            "floors"
-          ],
+          ["has", "height"],
+          ["get", "height"],
+          ["has", "floors"],
           [
             "*",
             [
               "to-number",
-              [
-                "get",
-                "floors"
-              ]
+              ["get", "floors"]
             ],
             2
           ],
@@ -636,26 +624,14 @@ export function nolabels_layers(
         ],
         "fill-extrusion-base": [
           "case",
-          [
-            "has",
-            "min_height"
-          ],
-          [
-            "get",
-            "min_height"
-          ],
-          [
-            "has",
-            "min_floors"
-          ],
+          ["has", "min_height"],
+          ["get", "min_height"],
+          ["has", "min_floors"],
           [
             "*",
             [
               "to-number",
-              [
-                "get",
-                "min_floors"
-              ]
+              ["get", "min_floors"]
             ],
             2
           ],


### PR DESCRIPTION
Hey,

You've got an awesome project, which apparently also included 3D-data. I wasn't aware of that as the basestyles don't leverage it.

I've added a small snippet to the basestyle to use that 3D-support to show it of. Copied it out of my own fork of the style (MapComplete-Sunny), so it _should_ work, but I have to admit that I didn't test it in the environment here.

Anyway, here is how it looks in [MapComplete](https://dev.mapcomplete.org/cyclofix.html?z=16.6&lat=51.054371466030716&lon=3.7246584907155693): 

<img width="970" height="658" alt="image" src="https://github.com/user-attachments/assets/ef93220b-7cc2-4865-bdd5-3b05ddce43d1" />
