### PR TITLE
fix: drop legacy-only place names

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Places.java
@@ -244,8 +244,39 @@ public class Places implements ForwardingProfile.LayerPostProcessor {
     return computedTags;
   }
 
+  private static boolean isCurrentNameKey(String key) {
+    return key.equals("name") || key.startsWith("name:");
+  }
+
+  private static boolean isOldNameKey(String key) {
+    return key.equals("old_name") ||
+      key.equals("old:name") ||
+      key.startsWith("old_name:") ||
+      key.startsWith("old:name:");
+  }
+
+  private static boolean hasAnyCurrentName(SourceFeature sf) {
+    return sf.tags().keySet().stream().anyMatch(Places::isCurrentNameKey);
+  }
+
+  private static boolean hasAnyOldName(SourceFeature sf) {
+    return sf.tags().keySet().stream().anyMatch(Places::isOldNameKey);
+  }
+
+  private static boolean isLegacyOnlyPlace(SourceFeature sf) {
+    return hasAnyOldName(sf) && !hasAnyCurrentName(sf);
+  }
+
   public void processOsm(SourceFeature sf, FeatureCollector features) {
-    if (!sf.isPoint() || !sf.hasTag("name") || !sf.hasTag("place")) {
+    if (!sf.isPoint() || !sf.hasTag("place")) {
+      return;
+    }
+
+    if (isLegacyOnlyPlace(sf)) {
+      return;
+    }
+
+    if (!hasAnyCurrentName(sf)) {
       return;
     }
 


### PR DESCRIPTION
The current processing doesn't handle cases where a point only has `old_name` keys and no `name` key which is sometimes used to indicate places which no longer exist.

Example from Hong Kong 

<img width="1192" height="979" alt="image" src="https://github.com/user-attachments/assets/eb95a8b8-28f9-407d-b901-8134c5509ce6" />

[Napier's Range](https://www.openstreetmap.org/node/11975533385) only has

<img width="409" height="176" alt="image" src="https://github.com/user-attachments/assets/c99ac33d-6977-4301-8469-2a3c91cfdd0c" />

old tags. With this fix, these points are filtered and the map only renders current names

<img width="1127" height="891" alt="image" src="https://github.com/user-attachments/assets/cea68e37-0f3b-40f6-b5b5-86e71d5ff9c7" />


