### PR TITLE
fix: parse population tags with thousands separators

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/feature/Matcher.java
+++ b/tiles/src/main/java/com/protomaps/basemap/feature/Matcher.java
@@ -305,8 +305,10 @@ public class Matcher {
         if (value instanceof Integer integerValue) {
           return integerValue;
         } else if (value instanceof FromTag fromTag) {
+          if (!sf.hasTag(fromTag.key)) return defaultValue;
           try {
-            return sf.hasTag(fromTag.key) ? Integer.valueOf(sf.getString(fromTag.key)) : defaultValue;
+            String digits = sf.getString(fromTag.key).replaceAll("[^0-9]", "");
+            return digits.isEmpty() ? defaultValue : Integer.valueOf(digits);
           } catch (NumberFormatException e) {
             return defaultValue;
           }

--- a/tiles/src/test/java/com/protomaps/basemap/feature/MatcherTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/feature/MatcherTest.java
@@ -562,6 +562,16 @@ class MatcherTest {
     );
     matches = index.getMatches(sf);
     assertEquals(1, getInteger(sf, matches, "a", 1));
+
+    sf = SimpleFeature.create(
+      newPoint(0, 0),
+      Map.of("b", "326 280"),
+      "osm",
+      null,
+      0
+    );
+    matches = index.getMatches(sf);
+    assertEquals(326280, getInteger(sf, matches, "a", 0));
   }
 
   @Test


### PR DESCRIPTION
This handles spaces, non-breaking spaces, commas, underscores, and any other thousands separator variants found in OSM data.

Closes #598

## Notes

`BasemapTest.testExtractBoundsFromValidGeoParquet` fails on main
before this change - not related to this PR.

## AI Assistance

This PR was created with the help of GitHub Copilot (Claude Sonnet 4.6).
All code changes have been reviewed and understood by a human contributor.