### PR TITLE
Add OSM elevation to point POIs

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -501,9 +501,7 @@ public class Pois implements ForwardingProfile.LayerPostProcessor {
 
     // Assign outputFeature
     if (hasNamedPolygon) {
-      outputFeature = features.pointOnSurface(this.name())
-        //.setAttr("area_debug", wayArea) // DEBUG
-        .setAttr("elevation", sf.getString("ele"));
+      outputFeature = features.pointOnSurface(this.name());
     } else if (sf.isPoint()) {
       outputFeature = features.point(this.name());
     } else {
@@ -525,7 +523,8 @@ public class Pois implements ForwardingProfile.LayerPostProcessor {
       .setZoomRange(Math.min(minZoom, 15), 15)
       // Core OSM tags for different kinds of places
       // Special airport only tag (to indicate if it's an airport with regular commercial flights)
-      .setAttr("iata", sf.getString("iata"));
+      .setAttr("iata", sf.getString("iata"))
+      .setAttr("elevation", sf.getString("ele"));
 
     // Core Tilezen schema properties
     if (!kindDetail.equals("pm:undefined"))

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -25,9 +25,14 @@ import com.protomaps.basemap.feature.QrankDb;
 import com.protomaps.basemap.names.OsmNames;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 @SuppressWarnings("java:S1192")
 public class Pois implements ForwardingProfile.LayerPostProcessor {
+
+  // Matches numeric metre values with an optional trailing "m" suffix, e.g. "569", "569.5", "569 m", or "569m".
+  private static final Pattern ELEVATION_PATTERN =
+    Pattern.compile("^([+-]?(?:\\d+(?:\\.\\d+)?|\\.\\d+))(?:\\s*m)?$");
 
   private Map<String, int[][]> qrankGrading = Map.of(
     "station", new int[][]{{10, 50000}, {12, 20000}, {13, 10000}},
@@ -45,6 +50,25 @@ public class Pois implements ForwardingProfile.LayerPostProcessor {
   }
 
   public static final String LAYER_NAME = "pois";
+
+  static Integer parseElevation(String elevation) {
+    if (elevation == null) {
+      return null;
+    }
+
+    var matcher = ELEVATION_PATTERN.matcher(elevation.trim());
+    if (!matcher.matches()) {
+      return null;
+    }
+
+    var parsed = parseDoubleOrNull(matcher.group(1));
+    if (parsed == null) {
+      return null;
+    }
+
+    var rounded = Math.round(parsed);
+    return rounded >= Integer.MIN_VALUE && rounded <= Integer.MAX_VALUE ? (int) rounded : null;
+  }
 
   private static final Expression WITH_OPERATOR_USFS = with("operator", "United States Forest Service",
     "US Forest Service", "U.S. Forest Service", "USDA Forest Service", "United States Department of Agriculture",
@@ -524,7 +548,7 @@ public class Pois implements ForwardingProfile.LayerPostProcessor {
       // Core OSM tags for different kinds of places
       // Special airport only tag (to indicate if it's an airport with regular commercial flights)
       .setAttr("iata", sf.getString("iata"))
-      .setAttr("elevation", sf.getString("ele"));
+      .setAttr("elevation", parseElevation(sf.getString("ele")));
 
     // Core Tilezen schema properties
     if (!kindDetail.equals("pm:undefined"))

--- a/tiles/src/test/java/com/protomaps/basemap/layers/PoisTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/PoisTest.java
@@ -1,6 +1,7 @@
 package com.protomaps.basemap.layers;
 
 import static com.onthegomap.planetiler.TestUtils.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.onthegomap.planetiler.reader.SimpleFeature;
 import java.util.HashMap;
@@ -200,12 +201,56 @@ class PoisTest extends LayerTest {
   @Test
   void peakElevation() {
     assertFeatures(14,
-      List.of(Map.of("kind", "peak", "min_zoom", 14, "elevation", "569")),
+      List.of(Map.of("kind", "peak", "min_zoom", 14, "elevation", 569)),
       process(SimpleFeature.create(
         newPoint(1, 1),
         new HashMap<>(Map.of("natural", "peak", "ele", "569")),
         "osm", null, 0
       )));
+  }
+
+  @Test
+  void peakElevationDecimal() {
+    assertFeatures(14,
+      List.of(Map.of("kind", "peak", "min_zoom", 14, "elevation", 570)),
+      process(SimpleFeature.create(
+        newPoint(1, 1),
+        new HashMap<>(Map.of("natural", "peak", "ele", "569.5")),
+        "osm", null, 0
+      )));
+  }
+
+  @Test
+  void peakElevationMeterSuffix() {
+    assertFeatures(14,
+      List.of(Map.of("kind", "peak", "min_zoom", 14, "elevation", 569)),
+      process(SimpleFeature.create(
+        newPoint(1, 1),
+        new HashMap<>(Map.of("natural", "peak", "ele", "569 m")),
+        "osm", null, 0
+      )));
+  }
+
+  @Test
+  void peakElevationMeterSuffixWithoutWhitespace() {
+    assertFeatures(14,
+      List.of(Map.of("kind", "peak", "min_zoom", 14, "elevation", 569)),
+      process(SimpleFeature.create(
+        newPoint(1, 1),
+        new HashMap<>(Map.of("natural", "peak", "ele", "569m")),
+        "osm", null, 0
+      )));
+  }
+
+  @Test
+  void peakElevationNonMeterUnitOmitted() {
+    var features = process(SimpleFeature.create(
+      newPoint(1, 1),
+      new HashMap<>(Map.of("natural", "peak", "ele", "569 ft")),
+      "osm", null, 0
+    ));
+
+    assertFalse(toMap(features.iterator().next(), 14).containsKey("elevation"));
   }
 
   @Test
@@ -640,7 +685,7 @@ class PoisTest extends LayerTest {
   @Test
   void zoom_12_tallBuilding_100mHeight() {
     assertFeatures(12,
-      List.of(Map.of("kind", "office", "min_zoom", 12, "name", "Skyscraper", "elevation", "100")),
+      List.of(Map.of("kind", "office", "min_zoom", 12, "name", "Skyscraper", "elevation", 100)),
       process(SimpleFeature.create(
         AREA_12K_SQ_M,
         new HashMap<>(Map.of(

--- a/tiles/src/test/java/com/protomaps/basemap/layers/PoisTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/PoisTest.java
@@ -198,6 +198,17 @@ class PoisTest extends LayerTest {
   }
 
   @Test
+  void peakElevation() {
+    assertFeatures(14,
+      List.of(Map.of("kind", "peak", "min_zoom", 14, "elevation", "569")),
+      process(SimpleFeature.create(
+        newPoint(1, 1),
+        new HashMap<>(Map.of("natural", "peak", "ele", "569")),
+        "osm", null, 0
+      )));
+  }
+
+  @Test
   void zoom_14_golfCourse() {
     assertFeatures(14,
       List.of(Map.of("kind", "golf_course", "min_zoom", 14)),


### PR DESCRIPTION
  **Overview**

  I recently switched my personal project, https://wogibt.es/, from OpenMapTiles to Protomaps. Most attributes had a clear equivalent, but mountain peak elevation was missing: OSM `ele` values were not being exposed as the `elevation`
  attribute on Protomaps POIs.

  I do not think this is intended behavior, since `natural=peak` features commonly rely on `ele` for displaying summit elevation.

  Example node: https://www.openstreetmap.org/node/1308250615/history/2

  Before:

  <img width="284" height="357" alt="image" src="https://github.com/user-attachments/assets/c6175beb-9302-4319-a03b-317eab38d842" />

  After:

  <img width="284" height="357" alt="image" src="https://github.com/user-attachments/assets/5069aec7-22f7-4aab-bf2b-9cb375c6c9c7" />

  **Technical details**

  `natural=peak` features are usually OSM point features. The POI layer already copied the OSM `ele` tag to `elevation`, but only in the named-polygon `pointOnSurface` path. Point POIs therefore lost the attribute even when the source
  feature had `ele`.

  This change moves the `elevation` assignment into the common POI attribute chain, so OSM POIs can carry `ele` through to the output feature. Existing named-polygon behavior is preserved, and Planetiler still omits the attribute when
  `ele` is absent.

  A regression test was added for `natural=peak` with `ele`.

  **Verification**

  Ran:

  - `PoisTest`
  - full `mvn package`
  - `spotless:check`
  - `git diff --check`
  - before/after Saarland PMTiles scans

  For the Saarland z15 scan:

  - Before: 0 / 489 peak features had `elevation`
  - After: 425 / 489 peak features had `elevation`

  The remaining 64 peak features do not have OSM `ele` in the source data.

  **AI assistance**

  This change was prepared with help from OpenAI Codex 5.5 xhigh.
