### PR TITLE
Fix area thresholds using floating point division

### DIFF
--- a/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Landuse.java
@@ -314,11 +314,11 @@ public class Landuse implements ForwardingProfile.LayerPostProcessor {
   public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) throws GeometryException {
     if (zoom == 15)
       return items;
-    int minArea = 400 / (4096 * 4096) * (256 * 256);
+    double minArea = 400d / (4096 * 4096) * (256 * 256);
     if (zoom == 6)
-      minArea = 600 / (4096 * 4096) * (256 * 256);
+      minArea = 600d / (4096 * 4096) * (256 * 256);
     else if (zoom <= 5)
-      minArea = 800 / (4096 * 4096) * (256 * 256);
+      minArea = 800d / (4096 * 4096) * (256 * 256);
     items = Area.filterArea(items, minArea);
 
     // We only care about park boundaries inside groups of adjacent parks at higher zooms when they are labeled

--- a/tiles/src/main/java/com/protomaps/basemap/postprocess/Area.java
+++ b/tiles/src/main/java/com/protomaps/basemap/postprocess/Area.java
@@ -20,7 +20,7 @@ public class Area {
       if (minArea > 0 && area < minArea) {
         // do nothing
       } else {
-        if (minArea < 30000 / (4096 * 4096) * (256 * 256)) {
+        if (minArea < 30000d / (4096 * 4096) * (256 * 256)) {
           Set<String> keys = new HashSet<>(item.tags().keySet());
           for (String key : keys) {
             if (key.equals("name") || key.startsWith("name:")) {

--- a/tiles/src/test/java/com/protomaps/basemap/layers/LanduseTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/LanduseTest.java
@@ -1,8 +1,11 @@
 package com.protomaps.basemap.layers;
 
 import static com.onthegomap.planetiler.TestUtils.newPolygon;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.onthegomap.planetiler.FeatureCollector;
+import com.onthegomap.planetiler.VectorTile;
+import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.reader.SimpleFeature;
 import java.util.HashMap;
 import java.util.List;
@@ -579,5 +582,19 @@ class LanduseTest extends LayerTest {
       processWith("boundary", "national_park",
         "protection_title", "National Park")
     );
+  }
+
+  @Test
+  void postProcessFiltersSmallPolygonsBelowZoom15() throws GeometryException {
+    var small = new VectorTile.Feature("landuse", 1,
+      VectorTile.encodeGeometry(newPolygon(0, 0, 1, 0, 1, 1, 0, 1, 0, 0)),
+      new HashMap<>(Map.of("kind", "park")));
+    var large = new VectorTile.Feature("landuse", 2,
+      VectorTile.encodeGeometry(newPolygon(0, 0, 2, 0, 2, 2, 0, 2, 0, 0)),
+      new HashMap<>(Map.of("kind", "park")));
+
+    var result = new Landuse().postProcess(14, List.of(small, large));
+
+    assertEquals(List.of(large), result);
   }
 }


### PR DESCRIPTION
Landuse post-processing and the shared Area name-stripping threshold used scaled area formulas such as:

    400 / (4096 * 4096) * (256 * 256)

    30000 / (4096 * 4096) * (256 * 256)

In Java these are evaluated with integer arithmetic because every operand is an integer literal. A one-line JShell check shows the bug:

    printf 'System.out.println(400 / (4096 * 4096) * (256 * 256));\nSystem.out.println(30000 / (4096 * 4096) * (256 * 256));\n/exit\n' | jshell -q

    jshell> 0

    jshell> 0

The fixed expressions force floating point division by making the numerator a double literal:

    printf 'System.out.println(400d / (4096 * 4096) * (256 * 256));\nSystem.out.println(30000d / (4096 * 4096) * (256 * 256));\n/exit\n' | jshell -q

    jshell> 1.5625

    jshell> 117.1875

The visible production effect today is in Landuse: the min-area filter at z<15 was disabled because the computed minArea was 0. The Area.java change fixes the same latent integer arithmetic in the shared name-stripping threshold, but current callers do not emit name tags through that branch, so it produced no visible Saarland PMTiles delta in this comparison.

git blame traces both bad expressions to commit 1c38928931cff01aae247ae146a48f77b30f271d (Brandon Liu, 2023-03-28 21:26:42 +0800, "finish port of area logic"). That same commit added Buildings.java calling Area.filterArea(items, 0), so the shared name-stripping threshold has been zero since Area.filterArea was introduced.

Add a Landuse regression test at z14 so a sub-threshold polygon is dropped while a larger polygon survives. This exercises the coordinate-space threshold directly and would fail if the formula regressed to integer division.

Saarland PMTiles comparison against origin/main using saarland-latest.osm.pbf:

  - landuse archive: 16,101,245 bytes before, 16,073,949 bytes after (-27,296)

  - landuse decoded features: 219,609 before, 218,167 after (-1,442)

  - landuse feature deltas by zoom: z8 -15, z9 -29, z10 -97, z11 -174, z12 -273, z13 -420, z14 -434; z6, z7, and z15 unchanged

  - buildings archive: 20,368,010 bytes before and after, identical SHA256

  - buildings decoded features: 1,007,114 before and after

Verification: mvn -q -Dtest=LanduseTest test, mvn -q package, mvn -q spotless:check, git diff --check, and before/after Saarland PMTiles scans.

AI assistance: this change was prepared with help from OpenAI Codex.