### PR TITLE
Handle the occupied Northern Cyprus boundary consistently across zoom levels

### DIFF
--- a/styles/src/base_layers.ts
+++ b/styles/src/base_layers.ts
@@ -1066,7 +1066,11 @@ export function nolabels_layers(
       type: "line",
       source: source,
       "source-layer": "boundaries",
-      filter: ["<=", "kind_detail", 2],
+      filter: [
+        "any",
+        ["<=", "kind_detail", 2],
+        ["all", ["==", "kind_detail", 3], ["==", "disputed", true]],
+      ],
       paint: {
         "line-color": t.boundaries,
         "line-width": 0.7,
@@ -1084,7 +1088,11 @@ export function nolabels_layers(
       type: "line",
       source: source,
       "source-layer": "boundaries",
-      filter: [">", "kind_detail", 2],
+      filter: [
+        "all",
+        [">", "kind_detail", 2],
+        ["none", ["all", ["==", "kind_detail", 3], ["==", "disputed", true]]],
+      ],
       paint: {
         "line-color": t.boundaries,
         "line-width": 0.4,

--- a/styles/test/base_layers.test.ts
+++ b/styles/test/base_layers.test.ts
@@ -20,3 +20,22 @@ test("the nolayers label has no labels", () => {
     assert.notEqual("symbol", layer.type);
   }
 });
+
+test("country boundary styling includes disputed level three boundaries", () => {
+  const boundaryLayers = nolabels_layers("dummy", LIGHT);
+  const country = boundaryLayers.find(
+    (layer) => layer.id === "boundaries_country",
+  );
+  const other = boundaryLayers.find((layer) => layer.id === "boundaries");
+
+  assert.deepEqual(country?.filter, [
+    "any",
+    ["<=", "kind_detail", 2],
+    ["all", ["==", "kind_detail", 3], ["==", "disputed", true]],
+  ]);
+  assert.deepEqual(other?.filter, [
+    "all",
+    [">", "kind_detail", 2],
+    ["none", ["all", ["==", "kind_detail", 3], ["==", "disputed", true]]],
+  ]);
+});

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Boundaries.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Boundaries.java
@@ -226,7 +226,10 @@ public class Boundaries implements ForwardingProfile.OsmRelationPreprocessor,
     if (relation.hasTag("type", "boundary") &&
       relation.hasTag("boundary", "administrative", "disputed", "claim")) {
       Integer adminLevel = Parse.parseIntOrNull(relation.getString("admin_level"));
-      Integer disputed = relation.hasTag("boundary", "disputed") || relation.hasTag("disputed", "yes") ||
+      boolean occupiedBoundary = adminLevel != null && adminLevel == 3 &&
+        relation.hasTag("border_type", "occupied");
+      Integer disputed = occupiedBoundary || relation.hasTag("boundary", "disputed") ||
+        relation.hasTag("disputed", "yes") ||
         relation.hasTag("disputed_by") || relation.hasTag("claimed_by") ? 1 : 0;
 
       if (adminLevel == null || adminLevel > 8)

--- a/tiles/src/test/java/com/protomaps/basemap/layers/BoundariesTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/BoundariesTest.java
@@ -74,6 +74,62 @@ class BoundariesTest extends LayerTest {
       collector);
   }
 
+  @Test
+  void testOccupiedAdminLevelThreeIsDisputedRegionBoundary() {
+    var infos = profile.preprocessOsmRelation(
+      new OsmElement.Relation(1,
+        Map.of("type", "boundary", "boundary", "administrative", "admin_level", "3", "border_type", "occupied"),
+        List.of(new OsmElement.Relation.Member(OsmElement.Type.WAY, 123, ""))));
+
+    var way = SimpleFeature.createFakeOsmFeature(
+      newLineString(0, 0, 1, 1),
+      new HashMap<>(),
+      "osm",
+      null,
+      123,
+      infos.stream().map(r -> new OsmReader.RelationMember<>("", r)).toList()
+    );
+
+    var collector = featureCollectorFactory.get(way);
+    profile.processFeature(way, collector);
+
+    assertFeatures(6,
+      List.of(Map.of(
+        "kind", "region",
+        "kind_detail", 3,
+        "disputed", true,
+        "sort_rank", 288,
+        "_minzoom", 6)),
+      collector);
+  }
+
+  @Test
+  void testOrdinaryAdminLevelThreeRemainsRegionBoundary() {
+    var infos = profile.preprocessOsmRelation(
+      new OsmElement.Relation(1, Map.of("type", "boundary", "boundary", "administrative", "admin_level", "3"),
+        List.of(new OsmElement.Relation.Member(OsmElement.Type.WAY, 123, ""))));
+
+    var way = SimpleFeature.createFakeOsmFeature(
+      newLineString(0, 0, 1, 1),
+      new HashMap<>(),
+      "osm",
+      null,
+      123,
+      infos.stream().map(r -> new OsmReader.RelationMember<>("", r)).toList()
+    );
+
+    var collector = featureCollectorFactory.get(way);
+    profile.processFeature(way, collector);
+
+    assertFeatures(6,
+      List.of(Map.of(
+        "kind", "region",
+        "kind_detail", 3,
+        "sort_rank", 289,
+        "_minzoom", 6)),
+      collector);
+  }
+
   @ParameterizedTest
   @CsvSource(value = {
     "disputed,yes",


### PR DESCRIPTION
## Overview

This PR addresses issue #511, where the Northern Cyprus boundary changes from disputed-country styling at low zoom to ordinary regional styling at higher zoom.

This PR marks the explicitly occupied OSM boundary as disputed and styles it consistently with its low-zoom representation.

The commits are backward-compatible when used independently. New PMTiles used with the old styles continue to render the boundary as before, and the updated styles used with old PMTiles also render it as before. Only combining both commits enables the new disputed-boundary treatment for Northern Cyprus.

## Changes

### 1. Mark occupied level 3 boundaries as disputed

OSM relation [2514541](https://www.openstreetmap.org/relation/2514541) Northern Cyprus, is tagged:

```
admin_level=3
border_type=occupied
boundary=administrative
```

Relations with the exact combination of admin_level=3 and border_type=occupied now receive disputed=true and the disputed sort_rank.

According to [Taginfo](https://taginfo.openstreetmap.org/tags/border_type%3Doccupied), border_type=occupied currently occurs exactly once in OSM, on this relation. The rule therefore affects only Northern Cyprus with the current OSM data.

The boundary remains kind=region, kind_detail=3, following its OSM classification.

### 2. Style disputed level 3 boundaries prominently

The bundled styles now render boundaries with:

```
kind_detail=3
disputed=true
```

using the emphasized disputed-boundary treatment.

This removes the visual change around Cyprus when transitioning between the Natural Earth and OSM zoom levels.

## Verification

- Added regression tests for occupied and ordinary level 3 relations.
- Added style filter coverage for disputed level 3 boundaries.
- Generated and visually inspected a Cyprus PMTiles extract.
- Full Maven package: 399 tests passed.
- Style tests, TypeScript, Biome, Spotless, and git diff --check passed.

## Closing statement
I’m not sure whether a single border justifies all this. For some use cases, showing disputed borders correctly can be important. But there are many similar cases around the world with different tagging, and keeping OSM and Natural Earth consistent makes the problem even worse.

The cleaner fix would be a change in OSM, but changing disputed-boundary tagging there is a huge can of worms and may simply be a waste of time. I’ll leave it to the maintainers to decide whether this is worth it.


## AI assistance
these changes and tests were prepared with help from OpenAI Codex.