### PR TITLE
Expand and render OSM aerialways and stations

### DIFF
--- a/sprites/flavors/dark.json
+++ b/sprites/flavors/dark.json
@@ -39,6 +39,7 @@
     "nature_reserve": "green",
     "aerodrome": "lapis",
     "train_station": "lapis",
+    "aerialway": "lapis",
     "bus_stop": "lapis",
     "ferry_terminal": "lapis",
     "stadium": "slategray",

--- a/sprites/flavors/light.json
+++ b/sprites/flavors/light.json
@@ -39,6 +39,7 @@
     "nature_reserve": "green",
     "aerodrome": "lapis",
     "train_station": "lapis",
+    "aerialway": "lapis",
     "bus_stop": "lapis",
     "ferry_terminal": "lapis",
     "stadium": "slategray",

--- a/styles/src/base_layers.ts
+++ b/styles/src/base_layers.ts
@@ -1062,6 +1062,29 @@ export function nolabels_layers(
       },
     },
     {
+      id: "roads_aerialway",
+      type: "line",
+      source: source,
+      "source-layer": "roads",
+      filter: ["==", "kind", "aerialway"],
+      paint: {
+        "line-color": t.railway,
+        "line-dasharray": [4, 1],
+        "line-opacity": 0.5,
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          3,
+          0,
+          6,
+          0.15,
+          18,
+          9,
+        ],
+      },
+    },
+    {
       id: "boundaries_country",
       type: "line",
       source: source,
@@ -1439,6 +1462,29 @@ export function labels_layers(
       },
     },
     {
+      id: "roads_labels_aerialway",
+      type: "symbol",
+      source: source,
+      "source-layer": "roads",
+      minzoom: 13,
+      filter: ["==", "kind", "aerialway"],
+      layout: {
+        "symbol-placement": "line",
+        "text-font": [t.regular || "Noto Sans Regular"],
+        "text-field": get_multiline_name(
+          lang,
+          script,
+          t.regular,
+        ) as DataDrivenPropertyValueSpecification<string>,
+        "text-size": 12,
+      },
+      paint: {
+        "text-color": t.roads_label_minor,
+        "text-halo-color": t.roads_label_minor_halo,
+        "text-halo-width": 1,
+      },
+    },
+    {
       id: "roads_labels_minor",
       type: "symbol",
       source: source,
@@ -1662,9 +1708,14 @@ export function labels_layers(
             ],
             layout: {
               "icon-image": [
-                "match",
-                ["get", "kind"],
-                "station",
+                "case",
+                [
+                  "all",
+                  ["==", ["get", "kind"], "station"],
+                  ["==", ["get", "kind_detail"], "aerialway"],
+                ],
+                "aerialway",
+                ["==", ["get", "kind"], "station"],
                 "train_station",
                 ["get", "kind"],
               ],

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Pois.java
@@ -85,6 +85,7 @@ public class Pois implements ForwardingProfile.LayerPostProcessor {
     rule(
       Expression.or(
         with("aeroway", "aerodrome"),
+        with("aerialway", "station"),
         with("amenity"),
         with("attraction"),
         with("boundary", "national_park", "protected_area"),
@@ -190,7 +191,13 @@ public class Pois implements ForwardingProfile.LayerPostProcessor {
 
     rule(with("sport"), use("pm:kindDetail", fromTag("sport"))),
     rule(with("religion"), use("pm:kindDetail", fromTag("religion"))),
-    rule(with("cuisine"), use("pm:kindDetail", fromTag("cuisine")))
+    rule(with("cuisine"), use("pm:kindDetail", fromTag("cuisine"))),
+    // Keep explicit aerialway stations ahead of generic railway classification on dual-tagged features.
+    rule(
+      with("aerialway", "station"),
+      use("pm:kind", fromTag("aerialway")),
+      use("pm:kindDetail", "aerialway")
+    )
 
   )).index();
 

--- a/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
+++ b/tiles/src/main/java/com/protomaps/basemap/layers/Roads.java
@@ -129,10 +129,28 @@ public class Roads implements ForwardingProfile.LayerPostProcessor, ForwardingPr
       use("minZoom", 13)
     ),
     rule(
-      with("aerialway", "cable_car"),
+      with("aerialway", "cable_car", "gondola", "mixed_lift"),
       use("kind", "aerialway"),
-      use("kindDetail", "cable_car"),
+      use("kindDetail", fromTag("aerialway")),
       use("minZoom", 11)
+    ),
+    rule(
+      with("aerialway", "chair_lift"),
+      use("kind", "aerialway"),
+      use("kindDetail", fromTag("aerialway")),
+      use("minZoom", 12)
+    ),
+    rule(
+      with("aerialway", "drag_lift", "t-bar", "j-bar", "platter", "rope_tow"),
+      use("kind", "aerialway"),
+      use("kindDetail", fromTag("aerialway")),
+      use("minZoom", 13)
+    ),
+    rule(
+      with("aerialway", "magic_carpet", "zip_line", "goods"),
+      use("kind", "aerialway"),
+      use("kindDetail", fromTag("aerialway")),
+      use("minZoom", 14)
     ),
     rule(
       with("man_made", "pier"),

--- a/tiles/src/test/java/com/protomaps/basemap/layers/PoisTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/PoisTest.java
@@ -1084,6 +1084,33 @@ class PoisTest extends LayerTest {
   }
 
   @Test
+  void aerialwayStationNode() {
+    assertFeatures(15,
+      List.of(Map.of("kind", "station", "kind_detail", "aerialway", "min_zoom", 16)),
+      process(SimpleFeature.create(
+        newPoint(1, 1),
+        new HashMap<>(Map.of("aerialway", "station")),
+        "osm", null, 0
+      )));
+  }
+
+  @Test
+  void aerialwayStationArea() {
+    assertFeatures(15,
+      List.of(Map.of(
+        "kind", "station",
+        "kind_detail", "aerialway",
+        "name", "Valley station",
+        "min_zoom", 16
+      )),
+      process(SimpleFeature.create(
+        AREA_127_SQ_M,
+        new HashMap<>(Map.of("aerialway", "station", "name", "Valley station")),
+        "osm", null, 0
+      )));
+  }
+
+  @Test
   void kind_bakery_generic() {
     assertFeatures(15,
       List.of(Map.of("kind", "bakery", "min_zoom", 17)),

--- a/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/layers/RoadsTest.java
@@ -459,16 +459,30 @@ class RoadsTest extends LayerTest {
     );
   }
 
-  @Test
-  void testAerialwayCableCar() {
+  @ParameterizedTest
+  @CsvSource({
+    "cable_car, 11",
+    "gondola, 11",
+    "mixed_lift, 11",
+    "chair_lift, 12",
+    "drag_lift, 13",
+    "t-bar, 13",
+    "j-bar, 13",
+    "platter, 13",
+    "rope_tow, 13",
+    "magic_carpet, 14",
+    "zip_line, 14",
+    "goods, 14"
+  })
+  void testAerialways(String aerialway, int minZoom) {
     assertFeatures(12,
       List.of(Map.of("kind", "aerialway",
-        "kind_detail", "cable_car",
-        "_minzoom", 11
+        "kind_detail", aerialway,
+        "_minzoom", minZoom
       )),
       processWithRelationAndCoords("",
         0, 0, 1, 1,
-        "aerialway", "cable_car"
+        "aerialway", aerialway
       )
     );
   }


### PR DESCRIPTION
## Overview

Protomaps currently exports only `aerialway=cable_car`. The other documented aerialway line types are discarded, and the bundled styles do not render even the existing cable-car features.

For example, the [Schauinslandbahn](https://www.openstreetmap.org/way/4040490) is correctly tagged as `aerialway=gondola`, so it is currently missing.

This PR expands aerialway extraction, adds explicitly mapped stations, and renders the resulting features in the bundled styles.

## Changes

| Feature | Before | After |
| --- | --- | --- |
| `aerialway=cable_car` ways | Exported | Unchanged |
| Other documented aerialway ways | Dropped | Exported |
| Way `kind_detail` | Hardcoded to `cable_car` | Original `aerialway` value |
| Explicit station nodes | Dropped | Exported as POIs |
| Named station areas | Dropped | Exported as point-on-surface POIs |
| Aerialway lines in bundled styles | Not rendered | Rendered |
| Aerialway names | Not rendered | Localized line labels |
| Aerialway stations | No dedicated icon | Existing aerialway sprite |
| Pylons | Dropped | Unchanged |
| Untagged endpoints | Not inferred as stations | Unchanged |

The tagging model and documented values are described by the [OSM aerialway documentation](https://wiki.openstreetmap.org/wiki/Key:aerialway) and [aerialway station documentation](https://wiki.openstreetmap.org/wiki/Tag:aerialway%3Dstation).

### Line types

| Minimum zoom | Values |
| ---: | --- |
| 11 | `cable_car`, `gondola`, `mixed_lift` |
| 12 | `chair_lift` |
| 13 | `drag_lift`, `t-bar`, `j-bar`, `platter`, `rope_tow` |
| 14 | `magic_carpet`, `zip_line`, `goods` |

All line features use:

```text
kind=aerialway
kind_detail=<original aerialway value>
```

Explicit stations use:

```text
kind=station
kind_detail=aerialway
```

Stations retain the existing POI zoom and QRank behavior. The implementation does not infer stations from untagged line endpoints.

## Styling

| Property | Treatment |
| --- | --- |
| Color | Existing railway color |
| Opacity | Existing railway opacity |
| Width | Existing railway width curve |
| Distinction | Longer dash pattern |
| Labels | Localized line names |
| Stations | Existing aerialway sprite |
| Railway stations | Existing `train_station` sprite, unchanged |

The data and style commits remain independently usable. Custom styles that already render `kind=aerialway` can use the expanded data without adopting the bundled style changes.

## Baden-Württemberg comparison

Both archives were generated from the same Geofabrik extract.

| Metric | Before | After |
| --- | ---: | ---: |
| Unique aerialway ways | 0 | 345 |
| Aerialway stations | 0 | 620 |
| Archive size | 664,928,838 bytes | 664,947,675 bytes |
| Size increase | | 18,837 bytes (0.0028%) |

The Schauinslandbahn is emitted as:

```text
kind=aerialway
kind_detail=gondola
```
and rendered like this
<img width="865" height="763" alt="image" src="https://github.com/user-attachments/assets/34eb5b7f-63eb-4523-9efd-7f54ce2eea64" />


AI assistance: these changes and tests were prepared with help from OpenAI Codex.
