### PR TITLE
Fix parsing of coordinate strings when locale is non-English [#628]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Tiles 4.15.2
+------
+- Fix parsing of commas in non-English locales [#628]
+
 Tiles 4.15.1
 ------
 - Change to generic Geopackage source for Natural Earth via @mxzinke and @wipfli [#626]

--- a/tiles/src/main/java/com/protomaps/basemap/Basemap.java
+++ b/tiles/src/main/java/com/protomaps/basemap/Basemap.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.hadoop.ParquetFileReader;
@@ -134,7 +135,7 @@ public class Basemap extends ForwardingProfile {
 
   @Override
   public String version() {
-    return "4.15.1";
+    return "4.15.2";
   }
 
   @Override
@@ -179,7 +180,7 @@ public class Basemap extends ForwardingProfile {
         Envelope bounds = geoparquet.primaryColumnMetadata().envelope();
 
         if (bounds != null && !bounds.isNull() && bounds.getArea() > 0) {
-          String boundsStr = String.format("%f,%f,%f,%f",
+          String boundsStr = String.format(Locale.ROOT, "%f,%f,%f,%f",
             bounds.getMinX(), bounds.getMinY(), bounds.getMaxX(), bounds.getMaxY());
           return java.util.Optional.of(boundsStr);
         }

--- a/tiles/src/test/java/com/protomaps/basemap/BasemapTest.java
+++ b/tiles/src/test/java/com/protomaps/basemap/BasemapTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
+import java.util.Locale;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -58,6 +59,25 @@ public class BasemapTest {
     // Verify bounds are valid (minX < maxX, minY < maxY)
     assertTrue(minX < maxX, "Min X should be less than Max X");
     assertTrue(minY < maxY, "Min Y should be less than Max Y");
+  }
+
+  @Test
+  void testExtractBoundsUsesRootLocale() {
+    // A locale with a comma decimal separator must not corrupt the comma-separated bounds string.
+    Path testFile = Path.of("src", "test", "resources", "test-bounds.parquet");
+    Locale previous = Locale.getDefault();
+    try {
+      Locale.setDefault(Locale.GERMANY);
+
+      Optional<String> boundsOpt = Basemap.extractBoundsFromGeoParquet(testFile);
+
+      assertTrue(boundsOpt.isPresent(), "Should extract bounds from valid GeoParquet file");
+      String boundsStr = boundsOpt.get();
+      assertEquals(4, boundsStr.split(",").length, "Bounds string should have 4 comma-separated values");
+      assertEquals(-122.4241767, Double.parseDouble(boundsStr.split(",")[0]), 0.0001, "Min X should match");
+    } finally {
+      Locale.setDefault(previous);
+    }
   }
 
   @Test


### PR DESCRIPTION
Fixes #628 