### PR TITLE
Upgrade dependencies

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,10 +9,10 @@
 			"version": "0.0.0",
 			"dependencies": {
 				"@maplibre/maplibre-gl-geocoder": "^1.9.4",
-				"@maplibre/maplibre-gl-inspect": "^1.8.1",
-				"maplibre-gl": "5.19.0",
+				"@maplibre/maplibre-gl-inspect": "^1.9.0",
+				"maplibre-gl": "^6.0.0",
 				"pixelmatch": "^5.3.0",
-				"pmtiles": "^4.3.0",
+				"pmtiles": "^4.5.0",
 				"sirv": "^3.0.0",
 				"solid-js": "^1.9.5"
 			},
@@ -28,27 +28,14 @@
 				"vitest": "^4.1.8"
 			}
 		},
-		"node_modules/@ampproject/remapping": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/helper-validator-identifier": "^7.29.7",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			},
@@ -57,9 +44,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.26.3",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
-			"integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+			"integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -67,22 +54,22 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
-			"integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.26.0",
-				"@babel/generator": "^7.26.0",
-				"@babel/helper-compilation-targets": "^7.25.9",
-				"@babel/helper-module-transforms": "^7.26.0",
-				"@babel/helpers": "^7.26.0",
-				"@babel/parser": "^7.26.0",
-				"@babel/template": "^7.25.9",
-				"@babel/traverse": "^7.25.9",
-				"@babel/types": "^7.26.0",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-compilation-targets": "^7.29.7",
+				"@babel/helper-module-transforms": "^7.29.7",
+				"@babel/helpers": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -98,16 +85,16 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.26.3",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
-			"integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+			"version": "7.29.8",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+			"integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.26.3",
-				"@babel/types": "^7.26.3",
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.25",
+				"@babel/parser": "^7.29.8",
+				"@babel/types": "^7.29.8",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
 			},
 			"engines": {
@@ -115,14 +102,14 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
-			"integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+			"integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.25.9",
-				"@babel/helper-validator-option": "^7.25.9",
+				"@babel/compat-data": "^7.29.7",
+				"@babel/helper-validator-option": "^7.29.7",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
@@ -131,30 +118,40 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@babel/helper-globals": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+			"integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
-			"integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+			"integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.25.9",
-				"@babel/types": "^7.25.9"
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
-			"integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+			"integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.25.9",
-				"@babel/helper-validator-identifier": "^7.25.9",
-				"@babel/traverse": "^7.25.9"
+				"@babel/helper-module-imports": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"@babel/traverse": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -174,9 +171,9 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -184,9 +181,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -194,9 +191,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-			"integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+			"integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -204,27 +201,27 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-			"integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+			"integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-			"integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+			"version": "7.29.8",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+			"integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.29.0"
+				"@babel/types": "^7.29.8"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -250,48 +247,48 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.28.6",
-				"@babel/parser": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.26.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
-			"integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+			"version": "7.29.8",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+			"integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.26.2",
-				"@babel/generator": "^7.26.3",
-				"@babel/parser": "^7.26.3",
-				"@babel/template": "^7.25.9",
-				"@babel/types": "^7.26.3",
-				"debug": "^4.3.1",
-				"globals": "^11.1.0"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.8",
+				"@babel/helper-globals": "^7.29.7",
+				"@babel/parser": "^7.29.8",
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.8",
+				"debug": "^4.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"version": "7.29.8",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+			"integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.28.5"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -496,18 +493,14 @@
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-			"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/set-array": "^1.2.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/sourcemap-codec": "^1.5.0",
 				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@jridgewell/remapping": {
@@ -530,16 +523,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@jridgewell/set-array": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.5.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -548,9 +531,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.25",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -558,24 +541,13 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
-		"node_modules/@mapbox/geojson-rewind": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
-			"integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
-			"dependencies": {
-				"get-stream": "^6.0.1",
-				"minimist": "^1.2.6"
-			},
-			"bin": {
-				"geojson-rewind": "geojson-rewind"
-			}
-		},
 		"node_modules/@mapbox/jsonlint-lines-primitives": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-			"integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+			"integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+			"license": "MIT",
 			"engines": {
-				"node": ">= 0.6"
+				"node": ">= 22"
 			}
 		},
 		"node_modules/@mapbox/point-geometry": {
@@ -585,41 +557,36 @@
 			"license": "ISC"
 		},
 		"node_modules/@mapbox/tiny-sdf": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz",
-			"integrity": "sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+			"integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/@mapbox/unitbezier": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
-			"integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+			"integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/@mapbox/vector-tile": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
-			"integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-3.0.0.tgz",
+			"integrity": "sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@mapbox/point-geometry": "~1.1.0",
 				"@types/geojson": "^7946.0.16",
-				"pbf": "^4.0.1"
-			}
-		},
-		"node_modules/@mapbox/whoots-js": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
-			"integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
-			"engines": {
-				"node": ">=6.0.0"
+				"pbf": "^5.0.0"
 			}
 		},
 		"node_modules/@maplibre/geojson-vt": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
-			"integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
-			"license": "ISC"
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
+			"integrity": "sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==",
+			"license": "ISC",
+			"dependencies": {
+				"kdbush": "^4.1.0"
+			}
 		},
 		"node_modules/@maplibre/maplibre-gl-geocoder": {
 			"version": "1.9.4",
@@ -641,30 +608,29 @@
 			}
 		},
 		"node_modules/@maplibre/maplibre-gl-inspect": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-inspect/-/maplibre-gl-inspect-1.8.1.tgz",
-			"integrity": "sha512-Wh+MpaksNNWwA6wyH94D0gNzJdd4fFeImO2nqLDO1AxdF4NAML+HTrLE3XjWmVSPOZ7dDi/0IAZ8dc4IakyT0g==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-inspect/-/maplibre-gl-inspect-1.9.0.tgz",
+			"integrity": "sha512-gaLiP6QSdoX7jjdhPX4neSV1B0dLNc/p69RCdoLvz3SpnbOssxAD0MXd308Wu3WJuVvfkaYnNc4B/GQTAYrAdQ==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"lodash.isequal": "^4.5.0",
 				"randomcolor": "^0.6.2"
 			},
 			"peerDependencies": {
-				"maplibre-gl": ">3.0.0"
+				"maplibre-gl": ">=3.0.0 <7.0.0"
 			}
 		},
 		"node_modules/@maplibre/maplibre-gl-style-spec": {
-			"version": "24.6.0",
-			"resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.6.0.tgz",
-			"integrity": "sha512-+lxMYE+DvInshwVrqSQ3CkW9YRwVlRXeDzfthVOa1c9pwK5d7YgCwhgFwlSmjJLvTXn4gL8EvPUGT620sk2Pzg==",
+			"version": "26.2.1",
+			"resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.2.1.tgz",
+			"integrity": "sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==",
 			"license": "ISC",
 			"dependencies": {
-				"@mapbox/jsonlint-lines-primitives": "~2.0.2",
-				"@mapbox/unitbezier": "^0.0.1",
+				"@mapbox/jsonlint-lines-primitives": "^2.0.3",
+				"@mapbox/unitbezier": "^1.0.0",
 				"json-stringify-pretty-compact": "^4.0.0",
 				"minimist": "^1.2.8",
 				"quickselect": "^3.0.0",
-				"rw": "^1.3.3",
 				"tinyqueue": "^3.0.0"
 			},
 			"bin": {
@@ -674,27 +640,23 @@
 			}
 		},
 		"node_modules/@maplibre/mlt": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.6.tgz",
-			"integrity": "sha512-rgtY3x65lrrfXycLf6/T22ZnjTg5WgIOsptOIoCaMZy4O4UAKTyZlYY0h6v8le721pTptF94U65yMDQkug+URw==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.12.tgz",
+			"integrity": "sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==",
 			"license": "(MIT OR Apache-2.0)",
 			"dependencies": {
 				"@mapbox/point-geometry": "^1.1.0"
 			}
 		},
 		"node_modules/@maplibre/vt-pbf": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
-			"integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.2.tgz",
+			"integrity": "sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==",
 			"license": "MIT",
 			"dependencies": {
 				"@mapbox/point-geometry": "^1.1.0",
-				"@mapbox/vector-tile": "^2.0.4",
-				"@maplibre/geojson-vt": "^5.0.4",
 				"@types/geojson": "^7946.0.16",
-				"@types/supercluster": "^7.1.3",
-				"pbf": "^4.0.1",
-				"supercluster": "^8.0.1"
+				"pbf": "^5.1.0"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
@@ -1438,15 +1400,6 @@
 				"undici-types": "~6.21.0"
 			}
 		},
-		"node_modules/@types/supercluster": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
-			"integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/geojson": "*"
-			}
-		},
 		"node_modules/@vitest/expect": {
 			"version": "4.1.8",
 			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
@@ -1631,10 +1584,23 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.11.15",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.15.tgz",
+			"integrity": "sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/browserslist": {
-			"version": "4.24.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
-			"integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
+			"version": "4.28.8",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+			"integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
 			"dev": true,
 			"funding": [
 				{
@@ -1652,10 +1618,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001688",
-				"electron-to-chromium": "^1.5.73",
-				"node-releases": "^2.0.19",
-				"update-browserslist-db": "^1.1.1"
+				"baseline-browser-mapping": "^2.11.12",
+				"caniuse-lite": "^1.0.30001809",
+				"electron-to-chromium": "^1.5.402",
+				"node-releases": "^2.0.53",
+				"update-browserslist-db": "^1.3.0"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -1679,9 +1646,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001690",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
-			"integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
+			"version": "1.0.30001809",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+			"integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -1822,15 +1789,15 @@
 			}
 		},
 		"node_modules/earcut": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
-			"integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+			"integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
 			"license": "ISC"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.76",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-			"integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+			"version": "1.5.411",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.411.tgz",
+			"integrity": "sha512-gglkxzokjHfawpGxq75XdBV2/l3BAPzrsMs70qgaZdTW5rpV1tC4MdgJVP9fN126bODA4ZJQkn1wryEzJyQXIg==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -2078,32 +2045,11 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/get-stream": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/gl-matrix": {
 			"version": "3.4.4",
 			"resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
 			"integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
 			"license": "MIT"
-		},
-		"node_modules/globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/gopd": {
 			"version": "1.2.0",
@@ -2337,9 +2283,9 @@
 			}
 		},
 		"node_modules/kdbush": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
-			"integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+			"integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
 			"license": "ISC"
 		},
 		"node_modules/lightningcss": {
@@ -2637,32 +2583,27 @@
 			}
 		},
 		"node_modules/maplibre-gl": {
-			"version": "5.19.0",
-			"resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.19.0.tgz",
-			"integrity": "sha512-REhYUN8gNP3HlcIZS6QU2uy8iovl31cXsrNDkCcqWSQbCkcpdYLczqDz5PVIwNH42UQNyvukjes/RoHPDrOUmQ==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.4.1.tgz",
+			"integrity": "sha512-KzxQKtfBu/pSz1C+yW1hNS9eyj2h2lC7ufdAi6/SEt177n3oAfDfmUmslRfJdXY7ReAFBcnvwsqmiyoDhtA9GQ==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@mapbox/geojson-rewind": "^0.5.2",
-				"@mapbox/jsonlint-lines-primitives": "^2.0.2",
 				"@mapbox/point-geometry": "^1.1.0",
-				"@mapbox/tiny-sdf": "^2.0.7",
-				"@mapbox/unitbezier": "^0.0.1",
-				"@mapbox/vector-tile": "^2.0.4",
-				"@mapbox/whoots-js": "^3.1.0",
-				"@maplibre/geojson-vt": "^5.0.4",
-				"@maplibre/maplibre-gl-style-spec": "^24.4.1",
-				"@maplibre/mlt": "^1.1.6",
-				"@maplibre/vt-pbf": "^4.2.1",
+				"@mapbox/tiny-sdf": "^2.2.0",
+				"@mapbox/unitbezier": "^1.0.0",
+				"@mapbox/vector-tile": "^3.0.0",
+				"@maplibre/geojson-vt": "^6.1.1",
+				"@maplibre/maplibre-gl-style-spec": "^26.2.1",
+				"@maplibre/mlt": "^1.1.12",
+				"@maplibre/vt-pbf": "^4.3.2",
 				"@types/geojson": "^7946.0.16",
-				"@types/supercluster": "^7.1.3",
-				"earcut": "^3.0.2",
+				"earcut": "^3.2.3",
 				"gl-matrix": "^3.4.4",
-				"kdbush": "^4.0.2",
+				"kdbush": "^4.1.0",
 				"murmurhash-js": "^1.0.0",
-				"pbf": "^4.0.1",
+				"pbf": "^5.1.2",
 				"potpack": "^2.1.0",
 				"quickselect": "^3.0.0",
-				"supercluster": "^8.0.1",
 				"tinyqueue": "^3.0.0"
 			},
 			"engines": {
@@ -2726,6 +2667,7 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
 			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -2752,9 +2694,9 @@
 			"integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"dev": true,
 			"funding": [
 				{
@@ -2771,11 +2713,14 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.19",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+			"version": "2.0.53",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+			"integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/nwsapi": {
 			"version": "2.2.16",
@@ -2819,9 +2764,9 @@
 			"license": "MIT"
 		},
 		"node_modules/pbf": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
-			"integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+			"integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"resolve-protobuf-schema": "^2.1.0"
@@ -2862,9 +2807,9 @@
 			}
 		},
 		"node_modules/pmtiles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-4.3.0.tgz",
-			"integrity": "sha512-wnzQeSiYT/MyO63o7AVxwt7+uKqU0QUy2lHrivM7GvecNy0m1A4voVyGey7bujnEW5Hn+ZzLdvHPoFaqrOzbPA==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-4.5.0.tgz",
+			"integrity": "sha512-CBeD4SoUluFziGdy/8k7FOjQxQy486n+929W/tWophauvMICpkZ26vGBWhDt/6b1FZQWNaf4jFdT/5+q0Wii5w==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"fflate": "^0.8.2"
@@ -2879,9 +2824,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.26",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+			"integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2899,7 +2844,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.17",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -2991,12 +2936,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/rw": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-			"integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3028,9 +2967,9 @@
 			}
 		},
 		"node_modules/seroval": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.0.tgz",
-			"integrity": "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/seroval/-/seroval-1.6.2.tgz",
+			"integrity": "sha512-mPT+SD2TrlB6wvte1KkYOYUkubaTbd6pZ/6Kk3C9nxzrHmCZyhxOO7XGAeL7f+yLKZglzGtM9odUVvg/EhO+vQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -3133,15 +3072,6 @@
 			"dependencies": {
 				"fuzzy": "^0.1.1",
 				"xtend": "^4.0.0"
-			}
-		},
-		"node_modules/supercluster": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
-			"integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
-			"license": "ISC",
-			"dependencies": {
-				"kdbush": "^4.0.2"
 			}
 		},
 		"node_modules/symbol-tree": {
@@ -3306,9 +3236,9 @@
 			"license": "MIT"
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-			"integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+			"integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -3327,7 +3257,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"escalade": "^3.2.0",
-				"picocolors": "^1.1.0"
+				"picocolors": "^1.1.1"
 			},
 			"bin": {
 				"update-browserslist-db": "cli.js"

--- a/app/package.json
+++ b/app/package.json
@@ -13,10 +13,10 @@
 	},
 	"dependencies": {
 		"@maplibre/maplibre-gl-geocoder": "^1.9.4",
-		"@maplibre/maplibre-gl-inspect": "^1.8.1",
-		"maplibre-gl": "5.19.0",
+		"@maplibre/maplibre-gl-inspect": "^1.9.0",
+		"maplibre-gl": "^6.0.0",
 		"pixelmatch": "^5.3.0",
-		"pmtiles": "^4.3.0",
+		"pmtiles": "^4.5.0",
 		"sirv": "^3.0.0",
 		"solid-js": "^1.9.5"
 	},

--- a/app/src/MapView.tsx
+++ b/app/src/MapView.tsx
@@ -20,6 +20,7 @@ import * as maplibregl from "maplibre-gl";
 import type {
   LngLatBoundsLike,
   MapGeoJSONFeature,
+  MapMouseEvent,
   MapTouchEvent,
   StyleSpecification,
 } from "maplibre-gl";
@@ -376,7 +377,7 @@ function MapLibreView(props: {
       });
     });
 
-    const showContextMenu = (e: MapTouchEvent) => {
+    const showContextMenu = (e: MapMouseEvent | MapTouchEvent) => {
       const features = map.queryRenderedFeatures(e.point);
       if (hiddenRef && features.length) {
         hiddenRef.innerHTML = "";
@@ -389,7 +390,7 @@ function MapLibreView(props: {
       }
     };
 
-    map.on("contextmenu", (e: MapTouchEvent) => {
+    map.on("contextmenu", (e: MapMouseEvent) => {
       showContextMenu(e);
     });
 
@@ -410,12 +411,9 @@ function MapLibreView(props: {
     map.on("touchend", clearLongPress);
     map.on("touchcancel", clearLongPress);
     map.on("touchmove", clearLongPress);
-    map.on("pointerdrag", clearLongPress);
-    map.on("pointermove", clearLongPress);
+    map.on("mousemove", clearLongPress);
+    map.on("drag", clearLongPress);
     map.on("moveend", clearLongPress);
-    map.on("gesturestart", clearLongPress);
-    map.on("gesturechange", clearLongPress);
-    map.on("gestureend", clearLongPress);
 
     mapRef = map;
 

--- a/app/src/MapView.tsx
+++ b/app/src/MapView.tsx
@@ -12,16 +12,18 @@ import {
   Popup,
   addProtocol,
   getRTLTextPluginStatus,
-  default as maplibregl,
   removeProtocol,
   setRTLTextPlugin,
+  setWorkerUrl,
 } from "maplibre-gl";
+import * as maplibregl from "maplibre-gl";
 import type {
   LngLatBoundsLike,
   MapGeoJSONFeature,
   MapTouchEvent,
   StyleSpecification,
 } from "maplibre-gl";
+import workerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
 import "maplibre-gl/dist/maplibre-gl.css";
 import {
   default as MaplibreGeocoder,
@@ -49,6 +51,8 @@ import {
   parseHash,
 } from "./utils";
 import "@maplibre/maplibre-gl-geocoder/dist/maplibre-gl-geocoder.css";
+
+setWorkerUrl(workerUrl);
 
 const STYLE_MAJOR_VERSION = 5;
 

--- a/app/src/VisualTests.tsx
+++ b/app/src/VisualTests.tsx
@@ -2,7 +2,8 @@
 import { render } from "solid-js/web";
 import "./index.css";
 import type { LayerSpecification } from "@maplibre/maplibre-gl-style-spec";
-import maplibregl from "maplibre-gl";
+import * as maplibregl from "maplibre-gl";
+import workerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
 import * as pmtiles from "pmtiles";
 import { For, createEffect, createSignal, onMount } from "solid-js";
 import { layers, namedFlavor } from "../../styles/src/index.ts";
@@ -12,6 +13,8 @@ import { layersForVersion } from "./utils";
 import "maplibre-gl/dist/maplibre-gl.css";
 // @ts-ignore
 import pixelmatch from "pixelmatch";
+
+maplibregl.setWorkerUrl(workerUrl);
 
 if (maplibregl.getRTLTextPluginStatus() === "unavailable") {
   maplibregl.setRTLTextPlugin(


### PR DESCRIPTION
Migrate to MapLibre GL v6 following the migration guide: https://maplibre.org/maplibre-gl-js/docs/guides/v5-to-v6-migration-guide/